### PR TITLE
fix: evitar falha de COPY com wildcard nos Dockerfiles

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,6 +12,10 @@ COPY src ./src
 
 # Gera o jar
 RUN mvn clean package -DskipTests
+RUN set -eux; \
+    jar="$(find target -maxdepth 1 -type f -name '*.jar' ! -name 'original-*.jar' | head -n 1)"; \
+    test -n "$jar"; \
+    cp "$jar" /app/app.jar
 
 
 # ---------- STAGE 2: RUNTIME ----------
@@ -20,7 +24,7 @@ FROM eclipse-temurin:21-jdk
 WORKDIR /app
 
 # Copia o jar gerado
-COPY --from=build /app/target/*.jar app.jar
+COPY --from=build /app/app.jar /app/app.jar
 
 EXPOSE 8080
 

--- a/backend/Dockerfile.seeder
+++ b/backend/Dockerfile.seeder
@@ -17,6 +17,10 @@ COPY src src
 
 # Compila o projeto (sem testes para acelerar)
 RUN ./gradlew build -x test --no-daemon
+RUN set -eux; \
+    jar="$(find build/libs -maxdepth 1 -type f -name '*.jar' ! -name '*-plain.jar' | head -n 1)"; \
+    test -n "$jar"; \
+    cp "$jar" /app/app.jar
 
 # Stage 2: Runtime apenas com JRE
 FROM eclipse-temurin:21-jre
@@ -24,7 +28,7 @@ FROM eclipse-temurin:21-jre
 WORKDIR /app
 
 # Copia o JAR compilado
-COPY --from=builder /app/build/libs/*.jar app.jar
+COPY --from=builder /app/app.jar /app/app.jar
 
 # Executa o SeedRunner como main class
 CMD ["java", "-cp", "app.jar", "-Dloader.main=com.ufape.projetobanquinhobd.seeder.SeedRunner", "org.springframework.boot.loader.launch.PropertiesLauncher"]


### PR DESCRIPTION
## Summary
- Torna o build do backend e do seeder determinístico ao selecionar explicitamente um único JAR no stage de build.
- Substitui `COPY` com wildcard por cópia de caminho fixo (`/app/app.jar`) para evitar erro em ambientes onde mais de um JAR é gerado.
- Remove a dependência de comportamento específico de versão/cache do Docker ao montar a imagem.