### PR TITLE
feat(db): adiciona views SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,3 +632,110 @@ Para mais detalhes técnicos sobre os seeders, consulte:
 
 - API: https://pokeapi.co/
 - Documentacao: https://pokeapi.co/docs/v2
+
+---
+
+## Views SQL
+
+As views foram criadas via migration Prisma e são aplicadas automaticamente ao subir o projeto com `docker compose up`.
+
+### View 1 — `v_resumo_batalhas_torneio`
+
+**Finalidade:** Apresenta um resumo completo de cada batalha disputada no sistema.
+
+**Colunas retornadas:**
+
+| Coluna | Descrição |
+|---|---|
+| `torneio_id` / `torneio_nome` | Identificação do torneio |
+| `batalha_id` | ID da batalha |
+| `rodada` | Fase da competição (1 = oitavas, 2 = quartas…) |
+| `horario_inicio` / `horario_fim` | Horários da batalha |
+| `duracao_minutos` | Tempo de duração calculado automaticamente |
+| `time_vencedor_id` / `time_vencedor_nome` | Vencedor do confronto |
+
+**Exemplos de consulta:**
+
+```sql
+-- Todas as batalhas da Liga Kanto Regional
+SELECT * FROM v_resumo_batalhas_torneio
+WHERE torneio_nome = 'Liga Kanto Regional';
+
+-- Ranking de batalhas por duração
+SELECT torneio_nome, rodada, time_vencedor_nome, duracao_minutos
+FROM v_resumo_batalhas_torneio
+ORDER BY duracao_minutos DESC;
+```
+
+---
+
+### View 2 — `v_time_pokemons_detalhado`
+
+**Finalidade:** Exibe a composição completa de cada time com todos os Pokémons, suas espécies, imagens e tipos.
+
+**Colunas retornadas:**
+
+| Coluna | Descrição |
+|---|---|
+| `time_id` / `time_nome` | Identificação do time |
+| `treinador_id` / `treinador_nome` | Dono do time |
+| `pokemon_id` / `pokemon_apelido` | Identificação do Pokémon |
+| `especie_nome` / `especie_imagem_url` | Espécie e sprite |
+| `tipos` | Tipos |
+
+**Exemplos de consulta:**
+
+```sql
+-- Todos os Pokémons do time de Ash
+SELECT pokemon_apelido, especie_nome, tipos
+FROM v_time_pokemons_detalhado
+WHERE treinador_nome = 'Ash Ketchum';
+
+-- Times que possuem Pokémons do tipo Fire
+SELECT DISTINCT time_nome, treinador_nome
+FROM v_time_pokemons_detalhado
+WHERE tipos LIKE '%Fire%';
+```
+
+---
+
+### View 3 — `v_treinador_desempenho_torneio`
+
+**Finalidade:** Apresenta o desempenho de cada treinador por torneio (total de batalhas, vitórias, derrotas e percentual de aproveitamento).
+
+**Colunas retornadas:**
+
+| Coluna | Descrição |
+|---|---|
+| `treinador_id` / `treinador_nome` | Identificação do treinador |
+| `torneio_id` / `torneio_nome` | Identificação do torneio |
+| `time_id` / `time_nome` | Time usado no torneio |
+| `total_batalhas` | Número de batalhas disputadas |
+| `total_vitorias` | Número de vitórias obtidas |
+| `total_derrotas` | Número de derrotas sofridas |
+| `percentual_vitorias` | Taxa de vitórias em % |
+
+**Exemplos de consulta:**
+
+```sql
+-- Ranking geral por percentual de vitórias
+SELECT treinador_nome, torneio_nome, total_batalhas,
+       total_vitorias, percentual_vitorias
+FROM v_treinador_desempenho_torneio
+ORDER BY percentual_vitorias DESC;
+
+-- Melhor treinador de cada torneio
+SELECT DISTINCT ON (torneio_nome)
+    torneio_nome, treinador_nome, percentual_vitorias
+FROM v_treinador_desempenho_torneio
+ORDER BY torneio_nome, percentual_vitorias DESC;
+
+-- Aproveitamento geral de um treinador em todos os torneios
+SELECT treinador_nome,
+       SUM(total_batalhas) AS batalhas_totais,
+       SUM(total_vitorias) AS vitorias_totais,
+       ROUND(SUM(total_vitorias)::NUMERIC / NULLIF(SUM(total_batalhas), 0) * 100, 2) AS aproveitamento_geral
+FROM v_treinador_desempenho_torneio
+WHERE treinador_nome = 'Ash Ketchum'
+GROUP BY treinador_nome;
+```

--- a/backend/db-schema/prisma/migrations/20260225120000/migration.sql
+++ b/backend/db-schema/prisma/migrations/20260225120000/migration.sql
@@ -1,0 +1,91 @@
+CREATE VIEW v_resumo_batalhas_torneio AS
+SELECT
+    t.id                                                              AS torneio_id,
+    t.nome                                                            AS torneio_nome,
+    b.id                                                              AS batalha_id,
+    b.rodada,
+    b.horario_inicio,
+    b.horario_fim,
+    ROUND(
+        EXTRACT(EPOCH FROM (b.horario_fim - b.horario_inicio)) / 60.0,
+        2
+    )                                                                 AS duracao_minutos,
+    tv.id                                                             AS time_vencedor_id,
+    tv.nome                                                           AS time_vencedor_nome
+FROM torneio t
+JOIN batalha b
+    ON b.torneio_id = t.id
+LEFT JOIN time tv
+    ON tv.id = b.time_vencedor_id
+GROUP BY
+    t.id, t.nome,
+    b.id, b.rodada, b.horario_inicio, b.horario_fim,
+    tv.id, tv.nome;
+
+CREATE VIEW v_time_pokemons_detalhado AS
+SELECT
+    tm.id                                                             AS time_id,
+    tm.nome                                                           AS time_nome,
+    tr.id                                                             AS treinador_id,
+    tr.nome                                                           AS treinador_nome,
+    p.id                                                              AS pokemon_id,
+    p.apelido                                                         AS pokemon_apelido,
+    e.nome                                                            AS especie_nome,
+    e.imagem_url                                                      AS especie_imagem_url,
+    STRING_AGG(DISTINCT et.tipos_nome, ', ' ORDER BY et.tipos_nome)   AS tipos
+FROM time tm
+JOIN treinador tr
+    ON tr.id = tm.treinador_id
+JOIN time_pokemons tp
+    ON tp.time_id = tm.id
+JOIN pokemon p
+    ON p.id = tp.pokemons_id
+LEFT JOIN especie e
+    ON e.nome = p.especie_nome
+LEFT JOIN especie_tipos et
+    ON et.especie_nome = e.nome
+GROUP BY
+    tm.id, tm.nome,
+    tr.id, tr.nome,
+    p.id, p.apelido,
+    e.nome, e.imagem_url;e;
+
+CREATE VIEW v_treinador_desempenho_torneio AS
+SELECT
+    tr.id                                                             AS treinador_id,
+    tr.nome                                                           AS treinador_nome,
+    tn.id                                                             AS torneio_id,
+    tn.nome                                                           AS torneio_nome,
+    tm.id                                                             AS time_id,
+    tm.nome                                                           AS time_nome,
+    COUNT(DISTINCT btp.batalha_id)                                    AS total_batalhas,
+    COUNT(DISTINCT CASE
+        WHEN b.time_vencedor_id = tm.id THEN b.id
+    END)                                                              AS total_vitorias,
+    COUNT(DISTINCT btp.batalha_id)
+        - COUNT(DISTINCT CASE
+            WHEN b.time_vencedor_id = tm.id THEN b.id
+          END)                                                         AS total_derrotas,
+    ROUND(
+        COUNT(DISTINCT CASE
+            WHEN b.time_vencedor_id = tm.id THEN b.id
+        END)::NUMERIC
+        / NULLIF(COUNT(DISTINCT btp.batalha_id), 0) * 100,
+        2
+    )                                                                 AS percentual_vitorias
+FROM treinador tr
+JOIN time tm
+    ON tm.treinador_id = tr.id
+JOIN torneio_times tt
+    ON tt.times_id = tm.id
+JOIN torneio tn
+    ON tn.id = tt.torneios_id
+LEFT JOIN batalha_times_participantes btp
+    ON btp.times_participantes_id = tm.id
+LEFT JOIN batalha b
+    ON b.id = btp.batalha_id
+   AND b.torneio_id = tn.id
+GROUP BY
+    tr.id, tr.nome,
+    tn.id, tn.nome,
+    tm.id, tm.nome;


### PR DESCRIPTION
Cria migration com três views que simplificam consultas complexas:

- v_resumo_batalhas_torneio: resume batalhas com torneio, rodada, duração calculada e time vencedor
- v_time_pokemons_detalhado: exibe composição completa dos times com espécie, imagem e tipos
- v_treinador_desempenho_torneio: exibe vitórias, derrotas e percentual de aproveitamento por treinador por torneio

Adiciona documentação das views no README com descrição de finalidade, colunas retornadas e exemplos de consulta.

Closes #39 