### PR TITLE
fix: containerizar frontend e corrigir migration prisma

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ consumidas pelo `docker-compose.yml` da raiz e por
    docker compose up --build
    ```
 
+   O servico `frontend` e buildado a partir de `frontend/Dockerfile` e inicia em modo de desenvolvimento.
+
 3. **As aplicacoes ficarao disponiveis em:**
 
    ```bash
@@ -45,6 +47,7 @@ consumidas pelo `docker-compose.yml` da raiz e por
 
 - O compose da raiz inclui banco, migrate, seeder, backend e frontend.
 - Se o arquivo `.env` nao existir, o `docker compose` usa valores padrao de desenvolvimento definidos em `docker-compose.yml`.
+- O frontend roda com hot reload via volume bind (`./frontend:/app`) e dependencia persistida em `frontend-node-modules`.
 
 #### Comandos uteis
 

--- a/backend/db-schema/prisma/migrations/20260225120000/migration.sql
+++ b/backend/db-schema/prisma/migrations/20260225120000/migration.sql
@@ -48,7 +48,7 @@ GROUP BY
     tm.id, tm.nome,
     tr.id, tr.nome,
     p.id, p.apelido,
-    e.nome, e.imagem_url;e;
+    e.nome, e.imagem_url;
 
 CREATE VIEW v_treinador_desempenho_torneio AS
 SELECT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,9 @@ services:
     restart: unless-stopped
 
   frontend:
-    image: node:22-slim
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
     container_name: projeto-banquinho-frontend
     working_dir: /app
     depends_on:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.angular
+.git
+npm-debug.log
+yarn-error.log

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:22-slim
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+EXPOSE 4200
+
+CMD ["npm", "run", "start", "--", "--host", "0.0.0.0", "--port", "4200"]


### PR DESCRIPTION
## Summary
- buildar o frontend via `frontend/Dockerfile` no compose e manter hot reload
- adicionar `.dockerignore` para reduzir contexto de build
- corrigir erro de SQL na migration e atualizar README com notas do frontend