### PR TITLE
Alinha ciclo de torneios por data e simplifica criação no frontend

### DIFF
--- a/backend/src/main/java/com/ufape/projetobanquinhobd/entities/Torneio.java
+++ b/backend/src/main/java/com/ufape/projetobanquinhobd/entities/Torneio.java
@@ -6,6 +6,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Calendar;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
@@ -79,7 +80,7 @@ public class Torneio {
         if (dataEncerramentoInscricoes == null) {
             throw new IllegalArgumentException("Data de encerramento de inscrições é obrigatória");
         }
-        if (dataAberturaInscricoes != null && dataEncerramentoInscricoes.before(dataAberturaInscricoes)) {
+        if (dataAberturaInscricoes != null && normalizeToDay(dataEncerramentoInscricoes).before(normalizeToDay(dataAberturaInscricoes))) {
             throw new IllegalArgumentException("Data de encerramento deve ser após a abertura");
         }
         this.dataEncerramentoInscricoes = dataEncerramentoInscricoes;
@@ -89,7 +90,7 @@ public class Torneio {
         if (dataInicio == null) {
             throw new IllegalArgumentException("Data de início é obrigatória");
         }
-        if (dataEncerramentoInscricoes != null && dataInicio.before(dataEncerramentoInscricoes)) {
+        if (dataEncerramentoInscricoes != null && normalizeToDay(dataInicio).before(normalizeToDay(dataEncerramentoInscricoes))) {
             throw new IllegalArgumentException("Data de início deve ser após o encerramento das inscrições");
         }
         this.dataInicio = dataInicio;
@@ -99,7 +100,7 @@ public class Torneio {
         if (dataFim == null) {
             throw new IllegalArgumentException("Data de fim é obrigatória");
         }
-        if (dataInicio != null && dataFim.before(dataInicio)) {
+        if (dataInicio != null && normalizeToDay(dataFim).before(normalizeToDay(dataInicio))) {
             throw new IllegalArgumentException("Data de fim deve ser após a data de início");
         }
         this.dataFim = dataFim;
@@ -107,6 +108,45 @@ public class Torneio {
 
     public Set<Time> getTimes() {
         return times;
+    }
+
+    @Transient
+    public String getStatusAtual() {
+        Date hoje = normalizeToDay(new Date());
+        Date fim = dataFim == null ? null : normalizeToDay(dataFim);
+        Date inicio = dataInicio == null ? null : normalizeToDay(dataInicio);
+
+        if (fim != null && hoje.after(fim)) {
+            return "ENCERRADO";
+        }
+
+        if (inicio != null && !hoje.before(inicio)) {
+            return "EM_ANDAMENTO";
+        }
+
+        return "ABERTO";
+    }
+
+    @Transient
+    public boolean isInscricoesAbertas() {
+        if (dataAberturaInscricoes == null || dataEncerramentoInscricoes == null) {
+            return false;
+        }
+
+        Date hoje = normalizeToDay(new Date());
+        Date abertura = normalizeToDay(dataAberturaInscricoes);
+        Date encerramento = normalizeToDay(dataEncerramentoInscricoes);
+        return !hoje.before(abertura) && !hoje.after(encerramento);
+    }
+
+    private Date normalizeToDay(Date date) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(date);
+        calendar.set(Calendar.HOUR_OF_DAY, 0);
+        calendar.set(Calendar.MINUTE, 0);
+        calendar.set(Calendar.SECOND, 0);
+        calendar.set(Calendar.MILLISECOND, 0);
+        return calendar.getTime();
     }
 
 }

--- a/backend/src/main/java/com/ufape/projetobanquinhobd/seeder/torneios/TorneioSeeder.java
+++ b/backend/src/main/java/com/ufape/projetobanquinhobd/seeder/torneios/TorneioSeeder.java
@@ -97,7 +97,7 @@ public class TorneioSeeder {
         Date dataInicio;
         Date dataFim;
 
-        TorneioConfig(int maxParticipantes, Date dataAbertura, Date dataEncerramento, 
+        TorneioConfig(int maxParticipantes, Date dataAbertura, Date dataEncerramento,
                      Date dataInicio, Date dataFim) {
             this.maxParticipantes = maxParticipantes;
             this.dataAberturaInscricoes = dataAbertura;

--- a/frontend/src/app/core/models/index.ts
+++ b/frontend/src/app/core/models/index.ts
@@ -60,7 +60,8 @@ export interface Batalha {
 export interface Torneio {
   id: number;
   nome: string;
-  descricao?: string;
+  statusAtual?: 'ABERTO' | 'EM_ANDAMENTO' | 'ENCERRADO';
+  inscricoesAbertas?: boolean;
   maxParticipantes: number;
   dataAberturaInscricoes: string; // Date será string no JSON
   dataEncerramentoInscricoes: string;

--- a/frontend/src/app/features/home/home.component.css
+++ b/frontend/src/app/features/home/home.component.css
@@ -562,6 +562,25 @@ body, html {
     inset 0 1px 0 rgba(255, 255, 255, 0.3);
 }
 
+.btn-tournament.btn-register {
+  background: linear-gradient(145deg, #2f8f46, #3fbf5a);
+  border-color: #1f6a33;
+}
+
+.btn-tournament.btn-register:hover:not(:disabled) {
+  background: linear-gradient(145deg, #3fbf5a, #57d977);
+}
+
+.btn-tournament.btn-register:disabled,
+.btn-tournament.btn-register:disabled:hover {
+  background: linear-gradient(145deg, #6a6a6a, #8a8a8a);
+  border-color: #555;
+  color: #e8e8e8;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.15);
+}
+
 .btn-tournament.btn-secondary {
   background: linear-gradient(145deg, #1a5fb4, #1976d2);
   color: white;
@@ -2274,59 +2293,6 @@ body, html {
   font-style: italic;
 }
 
-/* Tipos de Pokémon */
-.types-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
-  gap: 10px;
-  margin-top: 16px;
-}
-
-.type-badge {
-  padding: 10px 16px;
-  border: 3px solid #1a1a1a;
-  border-radius: 6px;
-  font-family: 'Press Start 2P', monospace;
-  font-size: 8px;
-  background: linear-gradient(145deg, #e0e0e0, #bdbdbd);
-  color: #1a1a1a;
-  cursor: pointer;
-  box-shadow: 2px 2px 0 #1a1a1a;
-  transition: all 0.2s ease;
-  text-align: center;
-}
-
-.type-badge:hover {
-  transform: translateY(-2px);
-  box-shadow: 3px 3px 0 #1a1a1a;
-}
-
-.type-badge.type-selected {
-  background: linear-gradient(145deg, #4daf50, #339933);
-  color: #ffffff;
-  border-color: #4daf50;
-  box-shadow: 3px 3px 0 #1a1a1a;
-}
-
-.selected-types-info {
-  font-family: 'Nunito', sans-serif;
-  font-size: 12px;
-  color: #4daf50;
-  margin: 12px 0 0;
-  padding: 12px;
-  background: rgba(77, 175, 80, 0.1);
-  border: 2px solid #4daf50;
-  border-radius: 6px;
-  font-weight: 600;
-}
-
-.selected-types-info.no-types {
-  color: #666;
-  background: rgba(0, 0, 0, 0.05);
-  border-color: #999;
-  font-weight: normal;
-}
-
 /* Conceitos de BD na página de criar */
 .concepts-section {
   background: linear-gradient(145deg, #e3f2fd, #bbdefb);
@@ -2412,15 +2378,6 @@ body, html {
 
   .form-row {
     grid-template-columns: 1fr;
-  }
-
-  .types-grid {
-    grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
-  }
-
-  .type-badge {
-    font-size: 7px;
-    padding: 8px 12px;
   }
 
   .concepts-grid {

--- a/frontend/src/app/features/home/home.component.html
+++ b/frontend/src/app/features/home/home.component.html
@@ -111,9 +111,7 @@
             <!-- Torneios Abertos (Inscrições) -->
             <div class="tournament-section" *ngIf="torneiosAbertos.length > 0">
               <h3 class="section-title">
-                <span class="status-badge status-open"
-                  >📝 Inscrições Abertas</span
-                >
+                <span class="status-badge status-open">📝 Abertos</span>
               </h3>
               <div class="tournaments-grid">
                 <div
@@ -154,10 +152,15 @@
                   </div>
                   <div class="tournament-actions">
                     <button
-                      class="btn-tournament btn-primary"
+                      class="btn-tournament btn-primary btn-register"
+                      [disabled]="!isInscricaoAberta(torneio)"
                       (click)="inscreverNoTorneio(torneio)"
                     >
-                      Inscrever-se
+                      {{
+                        isInscricaoAberta(torneio)
+                          ? 'Inscrever-se'
+                          : 'Inscrições Encerradas'
+                      }}
                     </button>
                     <button
                       class="btn-tournament btn-secondary"
@@ -1191,58 +1194,6 @@
             </div>
           </div>
 
-          <div class="form-row">
-            <div class="form-group full-width">
-              <label class="form-label" for="tournament-description"
-                >Descrição *</label
-              >
-              <textarea
-                id="tournament-description"
-                class="form-textarea"
-                [(ngModel)]="newTournament.description"
-                placeholder="Descreva o torneio, regras especiais, premiações, etc."
-                rows="4"
-                maxlength="500"
-              ></textarea>
-            </div>
-          </div>
-
-          <div class="form-row">
-            <div class="form-group">
-              <label class="form-label" for="tournament-organizer"
-                >Organizador (FK) *</label
-              >
-              <select
-                id="tournament-organizer"
-                class="form-select"
-                [(ngModel)]="newTournament.organizerId"
-              >
-                <option
-                  *ngFor="let org of availableOrganizers"
-                  [value]="org.id"
-                >
-                  {{ org.name }} ({{ org.tournaments }} torneios)
-                </option>
-              </select>
-              <small class="form-hint"
-                >SELECT id, name FROM users WHERE role = 'ADMIN'</small
-              >
-            </div>
-
-            <div class="form-group">
-              <label class="form-label" for="tournament-status">Status *</label>
-              <select
-                id="tournament-status"
-                class="form-select"
-                [(ngModel)]="newTournament.status"
-              >
-                <option value="SCHEDULED">Agendado</option>
-                <option value="REGISTRATION">Inscrições Abertas</option>
-                <option value="IN_PROGRESS">Em Andamento</option>
-                <option value="COMPLETED">Finalizado</option>
-              </select>
-            </div>
-          </div>
         </section>
 
         <!-- Datas -->
@@ -1251,14 +1202,26 @@
 
           <div class="form-row">
             <div class="form-group">
-              <label class="form-label" for="registration-deadline"
-                >Prazo de Inscrição *</label
+              <label class="form-label" for="registration-start-date"
+                >Abertura das Inscrições *</label
               >
               <input
-                type="datetime-local"
-                id="registration-deadline"
+                type="date"
+                id="registration-start-date"
                 class="form-input"
-                [(ngModel)]="newTournament.registrationDeadline"
+                [(ngModel)]="newTournament.registrationStartDate"
+              />
+            </div>
+
+            <div class="form-group">
+              <label class="form-label" for="registration-end-date"
+                >Encerramento das Inscrições *</label
+              >
+              <input
+                type="date"
+                id="registration-end-date"
+                class="form-input"
+                [(ngModel)]="newTournament.registrationEndDate"
               />
             </div>
 
@@ -1267,7 +1230,7 @@
                 >Data de Início *</label
               >
               <input
-                type="datetime-local"
+                type="date"
                 id="start-date"
                 class="form-input"
                 [(ngModel)]="newTournament.startDate"
@@ -1277,7 +1240,7 @@
             <div class="form-group">
               <label class="form-label" for="end-date">Data de Término *</label>
               <input
-                type="datetime-local"
+                type="date"
                 id="end-date"
                 class="form-input"
                 [(ngModel)]="newTournament.endDate"
@@ -1305,85 +1268,15 @@
               />
             </div>
 
-            <div class="form-group">
-              <label class="form-label" for="min-level">Nível Mínimo *</label>
-              <input
-                type="number"
-                id="min-level"
-                class="form-input"
-                [(ngModel)]="newTournament.minLevel"
-                min="1"
-                max="100"
-              />
-            </div>
-
-            <div class="form-group">
-              <label class="form-label" for="max-level">Nível Máximo *</label>
-              <input
-                type="number"
-                id="max-level"
-                class="form-input"
-                [(ngModel)]="newTournament.maxLevel"
-                min="1"
-                max="100"
-              />
-            </div>
-
-            <div class="form-group">
-              <label class="form-label" for="prize-pool">Premiação (₽) *</label>
-              <input
-                type="number"
-                id="prize-pool"
-                class="form-input"
-                [(ngModel)]="newTournament.prizePool"
-                min="0"
-                step="1000"
-              />
-            </div>
           </div>
-        </section>
-
-        <!-- Tipos Permitidos -->
-        <section class="form-section">
-          <h3 class="section-title">Tipos de Pokémon Permitidos</h3>
-          <p class="form-hint">
-            Relação N:N - Cada tipo selecionado gera um INSERT em
-            tournament_allowed_types
-          </p>
-
-          <div class="types-grid">
-            <button
-              *ngFor="let type of pokemonTypes"
-              type="button"
-              class="type-badge"
-              [class.type-selected]="isTypeSelected(type)"
-              (click)="togglePokemonType(type)"
-            >
-              {{ type }}
-            </button>
-          </div>
-
-          <p
-            class="selected-types-info"
-            *ngIf="newTournament.allowedTypes.length > 0"
-          >
-            ✅ {{ newTournament.allowedTypes.length }} tipo(s) selecionado(s):
-            {{ newTournament.allowedTypes.join(", ") }}
-          </p>
-          <p
-            class="selected-types-info no-types"
-            *ngIf="newTournament.allowedTypes.length === 0"
-          >
-            ℹ️ Nenhum tipo selecionado = Todos os tipos permitidos
-          </p>
         </section>
 
         <!-- Conceitos BD -->
         <section class="form-section concepts-section">
           <h3 class="section-title">🗄️ Conceitos de Banco de Dados</h3>
           <p class="tournament-subtitle">
-            💡 Esta tela demonstra múltiplos conceitos de BD: INSERT, chaves
-            estrangeiras, validações, tipos ENUM e timestamps automáticos
+            💡 Esta tela demonstra múltiplos conceitos de BD: INSERT, validações
+            e timestamps automáticos
           </p>
           <div class="concepts-grid">
             <div class="concept-card">
@@ -1393,35 +1286,15 @@
               </p>
             </div>
             <div class="concept-card">
-              <h4>Foreign Key</h4>
-              <p>
-                organizer_id referencia users(id) - garante integridade
-                referencial
-              </p>
-            </div>
-            <div class="concept-card">
-              <h4>Relação N:N</h4>
-              <p>
-                Tournament ↔ Types através da tabela tournament_allowed_types
-              </p>
-            </div>
-            <div class="concept-card">
               <h4>Validação</h4>
               <p>
-                Campos NOT NULL, CHECK constraints (min_level &lt; max_level)
+                Campos obrigatórios e regras de datas do torneio/inscrição
               </p>
             </div>
             <div class="concept-card">
               <h4>Timestamps</h4>
               <p>
                 created_at TIMESTAMP DEFAULT NOW() registra momento da criação
-              </p>
-            </div>
-            <div class="concept-card">
-              <h4>ENUM</h4>
-              <p>
-                Status usa tipo ENUM('SCHEDULED', 'REGISTRATION', 'IN_PROGRESS',
-                'COMPLETED')
               </p>
             </div>
           </div>

--- a/frontend/src/app/features/home/home.component.ts
+++ b/frontend/src/app/features/home/home.component.ts
@@ -51,47 +51,12 @@ export class HomeComponent implements OnInit {
   // Criar Torneio
   newTournament = {
     name: '',
-    description: '',
     startDate: '',
     endDate: '',
+    registrationStartDate: '',
+    registrationEndDate: '',
     maxParticipants: 16,
-    minLevel: 1,
-    maxLevel: 100,
-    allowedTypes: [] as string[],
-    organizerId: 1,
-    status: 'SCHEDULED',
-    prizePool: 10000,
-    registrationDeadline: '',
   };
-
-  // Mock data para dropdowns (simulando SELECT queries)
-  availableOrganizers = [
-    { id: 1, name: 'Admin Principal', tournaments: 12 },
-    { id: 2, name: 'Ash Ketchum', tournaments: 8 },
-    { id: 3, name: 'Professor Oak', tournaments: 15 },
-    { id: 4, name: 'Misty Waters', tournaments: 5 },
-  ];
-
-  pokemonTypes = [
-    'Normal',
-    'Fogo',
-    'Água',
-    'Elétrico',
-    'Planta',
-    'Gelo',
-    'Lutador',
-    'Venenoso',
-    'Terrestre',
-    'Voador',
-    'Psíquico',
-    'Inseto',
-    'Pedra',
-    'Fantasma',
-    'Dragão',
-    'Sombrio',
-    'Metálico',
-    'Fada',
-  ];
 
   // Mock data para demonstração das queries de BD
   mockStats = {
@@ -436,30 +401,24 @@ export class HomeComponent implements OnInit {
   }
 
   classificarTorneios(torneios: Torneio[]): void {
-    const hoje = new Date();
-    hoje.setHours(0, 0, 0, 0); // Zerar horas para comparação apenas de datas
-
     this.torneiosAbertos = [];
     this.torneiosEmAndamento = [];
     this.torneiosEncerrados = [];
 
     torneios.forEach((torneio) => {
-      const dataInicio = new Date(torneio.dataInicio);
-      const dataFim = new Date(torneio.dataFim);
+      const status = this.getStatusTorneio(torneio);
 
-      dataInicio.setHours(0, 0, 0, 0);
-      dataFim.setHours(0, 0, 0, 0);
-
-      if (dataFim < hoje) {
-        // Encerrado: data de fim já passou
+      if (status === 'ENCERRADO') {
         this.torneiosEncerrados.push(torneio);
-      } else if (dataInicio > hoje) {
-        // Aberto: ainda não começou (inscrições abertas)
-        this.torneiosAbertos.push(torneio);
-      } else {
-        // Em andamento: entre data de início e data de fim
-        this.torneiosEmAndamento.push(torneio);
+        return;
       }
+
+      if (status === 'EM_ANDAMENTO') {
+        this.torneiosEmAndamento.push(torneio);
+        return;
+      }
+
+      this.torneiosAbertos.push(torneio);
     });
 
     // Ordenar por data
@@ -619,31 +578,12 @@ export class HomeComponent implements OnInit {
   resetTournamentForm(): void {
     this.newTournament = {
       name: '',
-      description: '',
       startDate: '',
       endDate: '',
+      registrationStartDate: '',
+      registrationEndDate: '',
       maxParticipants: 16,
-      minLevel: 1,
-      maxLevel: 100,
-      allowedTypes: [],
-      organizerId: 1,
-      status: 'SCHEDULED',
-      prizePool: 10000,
-      registrationDeadline: '',
     };
-  }
-
-  togglePokemonType(type: string): void {
-    const index = this.newTournament.allowedTypes.indexOf(type);
-    if (index > -1) {
-      this.newTournament.allowedTypes.splice(index, 1);
-    } else {
-      this.newTournament.allowedTypes.push(type);
-    }
-  }
-
-  isTypeSelected(type: string): boolean {
-    return this.newTournament.allowedTypes.includes(type);
   }
 
   saveTournament(): void {
@@ -653,46 +593,27 @@ export class HomeComponent implements OnInit {
       '🗄️ SQL Simulado:',
       `
       INSERT INTO tournaments (
-        name, description, start_date, end_date, max_participants,
-        min_level, max_level, organizer_id, status, prize_pool,
-        registration_deadline, created_at
+        name, start_date, end_date,
+        max_participants,
+        registration_start_date, registration_end_date, created_at
       ) VALUES (
         '${this.newTournament.name}',
-        '${this.newTournament.description}',
         '${this.newTournament.startDate}',
         '${this.newTournament.endDate}',
         ${this.newTournament.maxParticipants},
-        ${this.newTournament.minLevel},
-        ${this.newTournament.maxLevel},
-        ${this.newTournament.organizerId},
-        '${this.newTournament.status}',
-        ${this.newTournament.prizePool},
-        '${this.newTournament.registrationDeadline}',
+        '${this.newTournament.registrationStartDate}',
+        '${this.newTournament.registrationEndDate}',
         NOW()
       );
     `,
     );
 
-    // Simular INSERT INTO tournament_allowed_types (relação N:N)
-    if (this.newTournament.allowedTypes.length > 0) {
-      console.log(
-        '🗄️ SQL Simulado (Tipos Permitidos):',
-        `
-        INSERT INTO tournament_allowed_types (tournament_id, type_name)
-        VALUES
-        ${this.newTournament.allowedTypes
-          .map((type) => `(LAST_INSERT_ID(), '${type}')`)
-          .join(',\n        ')};
-      `,
-      );
-    }
-
     // Na versão real, enviar para o backend
     const torneioParaSalvar: any = {
       nome: this.newTournament.name,
       maxParticipantes: this.newTournament.maxParticipants,
-      dataAberturaInscricoes: this.newTournament.registrationDeadline,
-      dataEncerramentoInscricoes: this.newTournament.registrationDeadline,
+      dataAberturaInscricoes: this.newTournament.registrationStartDate,
+      dataEncerramentoInscricoes: this.newTournament.registrationEndDate,
       dataInicio: this.newTournament.startDate,
       dataFim: this.newTournament.endDate,
     };
@@ -711,16 +632,29 @@ export class HomeComponent implements OnInit {
   }
 
   get isTournamentFormValid(): boolean {
+    const registrationStart = this.parseDateMs(
+      this.newTournament.registrationStartDate,
+    );
+    const registrationEnd = this.parseDateMs(this.newTournament.registrationEndDate);
+    const startDate = this.parseDateMs(this.newTournament.startDate);
+    const endDate = this.parseDateMs(this.newTournament.endDate);
+    const hasValidDateOrder =
+      registrationStart !== null &&
+      registrationEnd !== null &&
+      startDate !== null &&
+      endDate !== null &&
+      registrationStart <= registrationEnd &&
+      registrationEnd <= startDate &&
+      startDate <= endDate;
+
     return !!(
       this.newTournament.name.trim() &&
-      this.newTournament.description.trim() &&
       this.newTournament.startDate &&
       this.newTournament.endDate &&
-      this.newTournament.registrationDeadline &&
-      this.newTournament.maxParticipants > 0 &&
-      this.newTournament.minLevel >= 1 &&
-      this.newTournament.maxLevel <= 100 &&
-      this.newTournament.minLevel < this.newTournament.maxLevel
+      this.newTournament.registrationStartDate &&
+      this.newTournament.registrationEndDate &&
+      hasValidDateOrder &&
+      this.newTournament.maxParticipants > 0
     );
   }
 
@@ -835,12 +769,89 @@ export class HomeComponent implements OnInit {
     });
   }
 
+  isInscricaoAberta(torneio: Torneio): boolean {
+    if (typeof torneio.inscricoesAbertas === 'boolean') {
+      return torneio.inscricoesAbertas;
+    }
+
+    const agora = this.getTodayMs();
+    const abertura = this.parseDateMs(torneio.dataAberturaInscricoes);
+    const encerramento = this.parseDateMs(torneio.dataEncerramentoInscricoes);
+
+    if (abertura === null || encerramento === null) {
+      return false;
+    }
+
+    return agora >= abertura && agora <= encerramento;
+  }
+
   inscreverNoTorneio(torneio: Torneio): void {
+    if (!this.isInscricaoAberta(torneio)) {
+      alert(`As inscrições para ${torneio.nome} estão encerradas.`);
+      return;
+    }
+
     // TODO: Implementar lógica de inscrição quando houver o endpoint
     alert(`Você se inscreveu no torneio: ${torneio.nome}`);
   }
 
   verDetalhesTorneio(torneio: Torneio): void {
     this.router.navigate(['/tournament', torneio.id]);
+  }
+
+  private getStatusTorneio(
+    torneio: Torneio,
+  ): 'ABERTO' | 'EM_ANDAMENTO' | 'ENCERRADO' {
+    if (
+      torneio.statusAtual === 'ABERTO' ||
+      torneio.statusAtual === 'EM_ANDAMENTO' ||
+      torneio.statusAtual === 'ENCERRADO'
+    ) {
+      return torneio.statusAtual;
+    }
+
+    const agora = this.getTodayMs();
+    const inicio = this.parseDateMs(torneio.dataInicio);
+    const fim = this.parseDateMs(torneio.dataFim);
+
+    if (fim !== null && agora > fim) {
+      return 'ENCERRADO';
+    }
+
+    if (inicio !== null && agora >= inicio) {
+      return 'EM_ANDAMENTO';
+    }
+
+    return 'ABERTO';
+  }
+
+  private parseDateMs(dateValue: string): number | null {
+    const parsedDate = this.parseDate(dateValue);
+    if (!parsedDate) {
+      return null;
+    }
+
+    parsedDate.setHours(0, 0, 0, 0);
+    const timestamp = parsedDate.getTime();
+    return Number.isNaN(timestamp) ? null : timestamp;
+  }
+
+  private getTodayMs(): number {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    return today.getTime();
+  }
+
+  private parseDate(dateValue: string): Date | null {
+    const onlyDateMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateValue);
+    if (onlyDateMatch) {
+      const year = Number(onlyDateMatch[1]);
+      const month = Number(onlyDateMatch[2]) - 1;
+      const day = Number(onlyDateMatch[3]);
+      return new Date(year, month, day);
+    }
+
+    const parsed = new Date(dateValue);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
   }
 }

--- a/frontend/src/app/features/tournament-view/tournament-view.component.css
+++ b/frontend/src/app/features/tournament-view/tournament-view.component.css
@@ -117,13 +117,6 @@
   font-weight: 500;
 }
 
-.tournament-description {
-  color: #718096;
-  font-size: 16px;
-  line-height: 1.6;
-  margin-top: 12px;
-}
-
 /* ---- LOADING & ERROR ---- */
 .loading-container,
 .error-container {

--- a/frontend/src/app/features/tournament-view/tournament-view.component.html
+++ b/frontend/src/app/features/tournament-view/tournament-view.component.html
@@ -23,9 +23,6 @@
           👥 {{ torneio.maxParticipantes }} participantes
         </span>
       </div>
-      <p class="tournament-description" *ngIf="torneio.descricao">
-        {{ torneio.descricao }}
-      </p>
     </div>
   </header>
 


### PR DESCRIPTION
## Resumo
- Alinha a classificação de torneios (`ABERTO`, `EM_ANDAMENTO`, `ENCERRADO`) e a janela de inscrições para comparar apenas por data no backend e no frontend.
- Atualiza a listagem da home para usar `statusAtual`/`inscricoesAbertas` quando disponíveis e aplica fallback consistente por data.
- Simplifica o fluxo de criação de torneio no frontend removendo campos não persistidos (status manual, organizador, descrição, premiação, níveis e tipos permitidos), mantendo somente campos suportados.
- Ajusta UX do botão de inscrição com estado habilitado/desabilitado e estilos visuais coerentes.

## Motivação
A tela de criação estava permitindo configurar dados que não eram persistidos e a classificação estava sensível a horário, causando inconsistências em bordas de data. Esta mudança centraliza a regra por dia e mantém a interface alinhada ao que de fato existe no domínio.