### PR TITLE
fix: corrigir cálculo da v_treinador_desempenho_torneio

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,6 +725,12 @@ WHERE tipos LIKE '%Fire%';
 | `total_derrotas` | Número de derrotas sofridas |
 | `percentual_vitorias` | Taxa de vitórias em % |
 
+**Regra de cálculo:**
+
+- `total_batalhas` considera apenas batalhas do time dentro do torneio da linha.
+- `total_derrotas` conta somente batalhas finalizadas com vencedor diferente do time.
+- `percentual_vitorias` usa `vitorias / batalhas finalizadas`, com proteção para divisão por zero.
+
 **Exemplos de consulta:**
 
 ```sql

--- a/backend/db-schema/prisma/migrations/20260225120000_views_torneio_time_treinador/migration.sql
+++ b/backend/db-schema/prisma/migrations/20260225120000_views_torneio_time_treinador/migration.sql
@@ -58,19 +58,26 @@ SELECT
     tn.nome                                                           AS torneio_nome,
     tm.id                                                             AS time_id,
     tm.nome                                                           AS time_nome,
-    COUNT(DISTINCT btp.batalha_id)                                    AS total_batalhas,
+    COUNT(DISTINCT b.id)                                              AS total_batalhas,
     COUNT(DISTINCT CASE
         WHEN b.time_vencedor_id = tm.id THEN b.id
     END)                                                              AS total_vitorias,
-    COUNT(DISTINCT btp.batalha_id)
-        - COUNT(DISTINCT CASE
-            WHEN b.time_vencedor_id = tm.id THEN b.id
-          END)                                                         AS total_derrotas,
+    COUNT(DISTINCT CASE
+        WHEN b.time_vencedor_id IS NOT NULL
+         AND b.time_vencedor_id <> tm.id THEN b.id
+    END)                                                              AS total_derrotas,
     ROUND(
-        COUNT(DISTINCT CASE
-            WHEN b.time_vencedor_id = tm.id THEN b.id
-        END)::NUMERIC
-        / NULLIF(COUNT(DISTINCT btp.batalha_id), 0) * 100,
+        (
+            COUNT(DISTINCT CASE
+                WHEN b.time_vencedor_id = tm.id THEN b.id
+            END)::NUMERIC
+            / NULLIF(
+                COUNT(DISTINCT CASE
+                    WHEN b.time_vencedor_id IS NOT NULL THEN b.id
+                END),
+                0
+            )
+        ) * 100,
         2
     )                                                                 AS percentual_vitorias
 FROM treinador tr

--- a/docs/views-sql.md
+++ b/docs/views-sql.md
@@ -120,6 +120,12 @@ Apresenta o desempenho de cada treinador por torneio (total de batalhas, vitóri
 | `total_derrotas`       | Número de derrotas sofridas           |
 | `percentual_vitorias`  | Taxa de vitórias em % (arredondado)   |
 
+### **Regra de cálculo**
+
+- `total_batalhas` considera apenas batalhas do time dentro do torneio da linha.
+- `total_derrotas` conta somente batalhas finalizadas com vencedor diferente do time.
+- `percentual_vitorias` usa `vitorias / batalhas finalizadas`, com proteção para divisão por zero.
+
 ### **Exemplos de Consulta**
 
 ```sql


### PR DESCRIPTION
## Summary
- Corrige a view `v_treinador_desempenho_torneio` para contar `total_batalhas` apenas dentro do torneio da linha.
- Ajusta o cálculo de `total_derrotas` para considerar apenas batalhas finalizadas perdidas, sem tratar partidas sem vencedor como derrota.
- Atualiza `README.md` e `docs/views-sql.md` com as regras de cálculo da view.