### PR TITLE
feat: gerenciamento de pokémons, times e ataques por treinador

### DIFF
--- a/backend/src/main/java/com/ufape/projetobanquinhobd/controllers/TreinadorController.java
+++ b/backend/src/main/java/com/ufape/projetobanquinhobd/controllers/TreinadorController.java
@@ -1,15 +1,21 @@
 package com.ufape.projetobanquinhobd.controllers;
 
+import com.ufape.projetobanquinhobd.dto.PokemonRequest;
+import com.ufape.projetobanquinhobd.dto.PokemonAtaquesRequest;
+import com.ufape.projetobanquinhobd.dto.TimeRequest;
+import com.ufape.projetobanquinhobd.entities.Ataque;
 import com.ufape.projetobanquinhobd.entities.Treinador;
 import com.ufape.projetobanquinhobd.entities.Time;
 import com.ufape.projetobanquinhobd.entities.Pokemon;
 import com.ufape.projetobanquinhobd.facade.Fachada;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @RestController
 @RequestMapping("/api/treinadores")
@@ -104,6 +110,110 @@ public class TreinadorController {
     public ResponseEntity<Void> deletarTime(@PathVariable("id") Long id) {
         fachada.getTimeService().deletarPorId(id);
         return ResponseEntity.noContent().build();
+    }
+
+    // Times por treinador
+    @GetMapping("/{treinadorId}/times")
+    public List<Time> listarTimesDoTreinador(@PathVariable("treinadorId") Long treinadorId) {
+        return fachada.getTimeService().listarPorTreinador(treinadorId);
+    }
+
+    @PostMapping("/{treinadorId}/times")
+    public ResponseEntity<Time> criarTimeParaTreinador(
+            @PathVariable("treinadorId") Long treinadorId,
+            @RequestBody TimeRequest request) {
+        Time criado = fachada.getTimeService()
+                .criarParaTreinador(treinadorId, request.nome(), request.pokemonIds());
+        return ResponseEntity.status(HttpStatus.CREATED).body(criado);
+    }
+
+    @PutMapping("/{treinadorId}/times/{timeId}")
+    public ResponseEntity<Time> atualizarTimeDoTreinador(
+            @PathVariable("treinadorId") Long treinadorId,
+            @PathVariable("timeId") Long timeId,
+            @RequestBody TimeRequest request) {
+        Time atualizado = fachada.getTimeService()
+                .atualizarParaTreinador(treinadorId, timeId, request.nome(), request.pokemonIds());
+        return ResponseEntity.ok(atualizado);
+    }
+
+    @DeleteMapping("/{treinadorId}/times/{timeId}")
+    public ResponseEntity<Void> removerTimeDoTreinador(
+            @PathVariable("treinadorId") Long treinadorId,
+            @PathVariable("timeId") Long timeId) {
+        fachada.getTimeService().removerParaTreinador(treinadorId, timeId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // Pokémon por treinador
+    @GetMapping("/{treinadorId}/pokemons")
+    public List<Pokemon> listarPokemonsDoTreinador(@PathVariable("treinadorId") Long treinadorId) {
+        return fachada.getPokemonService().listarPorTreinador(treinadorId);
+    }
+
+    @PostMapping("/{treinadorId}/pokemons")
+    public ResponseEntity<Pokemon> criarPokemonParaTreinador(
+            @PathVariable("treinadorId") Long treinadorId,
+            @RequestBody PokemonRequest request) {
+        Pokemon criado = fachada.getPokemonService()
+                .criarParaTreinador(treinadorId, request.apelido(), request.especieNome());
+        return ResponseEntity.status(HttpStatus.CREATED).body(criado);
+    }
+
+    @PutMapping("/{treinadorId}/pokemons/{pokemonId}")
+    public ResponseEntity<Pokemon> atualizarPokemonDoTreinador(
+            @PathVariable("treinadorId") Long treinadorId,
+            @PathVariable("pokemonId") Long pokemonId,
+            @RequestBody PokemonRequest request) {
+        Pokemon atualizado = fachada.getPokemonService()
+                .atualizarParaTreinador(treinadorId, pokemonId, request.apelido(), request.especieNome());
+        return ResponseEntity.ok(atualizado);
+    }
+
+    @DeleteMapping("/{treinadorId}/pokemons/{pokemonId}")
+    public ResponseEntity<Void> removerPokemonDoTreinador(
+            @PathVariable("treinadorId") Long treinadorId,
+            @PathVariable("pokemonId") Long pokemonId) {
+        fachada.getPokemonService().removerParaTreinador(treinadorId, pokemonId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/{treinadorId}/pokemons/{pokemonId}/ataques")
+    public ResponseEntity<Set<Ataque>> listarAtaquesDoPokemon(
+            @PathVariable("treinadorId") Long treinadorId,
+            @PathVariable("pokemonId") Long pokemonId) {
+        Set<Ataque> ataques = fachada.getPokemonService().listarAtaquesDoPokemon(treinadorId, pokemonId);
+        return ResponseEntity.ok(ataques);
+    }
+
+    @PutMapping("/{treinadorId}/pokemons/{pokemonId}/ataques")
+    public ResponseEntity<Pokemon> definirAtaquesDoPokemon(
+            @PathVariable("treinadorId") Long treinadorId,
+            @PathVariable("pokemonId") Long pokemonId,
+            @RequestBody PokemonAtaquesRequest request) {
+        Pokemon atualizado = fachada.getPokemonService()
+                .definirAtaquesDoPokemon(treinadorId, pokemonId, request.ataquesNomes());
+        return ResponseEntity.ok(atualizado);
+    }
+
+    @PostMapping("/{treinadorId}/pokemons/{pokemonId}/ataques/{ataqueNome}")
+    public ResponseEntity<Pokemon> adicionarAtaqueAoPokemon(
+            @PathVariable("treinadorId") Long treinadorId,
+            @PathVariable("pokemonId") Long pokemonId,
+            @PathVariable("ataqueNome") String ataqueNome) {
+        Pokemon atualizado = fachada.getPokemonService()
+                .adicionarAtaqueAoPokemon(treinadorId, pokemonId, ataqueNome);
+        return ResponseEntity.ok(atualizado);
+    }
+
+    @DeleteMapping("/{treinadorId}/pokemons/{pokemonId}/ataques/{ataqueNome}")
+    public ResponseEntity<Pokemon> removerAtaqueDoPokemon(
+            @PathVariable("treinadorId") Long treinadorId,
+            @PathVariable("pokemonId") Long pokemonId,
+            @PathVariable("ataqueNome") String ataqueNome) {
+        Pokemon atualizado = fachada.getPokemonService()
+                .removerAtaqueDoPokemon(treinadorId, pokemonId, ataqueNome);
+        return ResponseEntity.ok(atualizado);
     }
 
     // Pokemon endpoints

--- a/backend/src/main/java/com/ufape/projetobanquinhobd/dto/PokemonAtaquesRequest.java
+++ b/backend/src/main/java/com/ufape/projetobanquinhobd/dto/PokemonAtaquesRequest.java
@@ -1,0 +1,6 @@
+package com.ufape.projetobanquinhobd.dto;
+
+import java.util.List;
+
+public record PokemonAtaquesRequest(List<String> ataquesNomes) {
+}

--- a/backend/src/main/java/com/ufape/projetobanquinhobd/dto/PokemonRequest.java
+++ b/backend/src/main/java/com/ufape/projetobanquinhobd/dto/PokemonRequest.java
@@ -1,0 +1,4 @@
+package com.ufape.projetobanquinhobd.dto;
+
+public record PokemonRequest(String apelido, String especieNome) {
+}

--- a/backend/src/main/java/com/ufape/projetobanquinhobd/dto/TimeRequest.java
+++ b/backend/src/main/java/com/ufape/projetobanquinhobd/dto/TimeRequest.java
@@ -1,0 +1,6 @@
+package com.ufape.projetobanquinhobd.dto;
+
+import java.util.List;
+
+public record TimeRequest(String nome, List<Long> pokemonIds) {
+}

--- a/backend/src/main/java/com/ufape/projetobanquinhobd/repositories/PokemonRepository.java
+++ b/backend/src/main/java/com/ufape/projetobanquinhobd/repositories/PokemonRepository.java
@@ -3,5 +3,10 @@ package com.ufape.projetobanquinhobd.repositories;
 import com.ufape.projetobanquinhobd.entities.Pokemon;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface PokemonRepository extends JpaRepository<Pokemon, Long> {
+    List<Pokemon> findByTreinadorId(Long treinadorId);
+    Optional<Pokemon> findByIdAndTreinadorId(Long id, Long treinadorId);
 }

--- a/backend/src/main/java/com/ufape/projetobanquinhobd/repositories/TimeRepository.java
+++ b/backend/src/main/java/com/ufape/projetobanquinhobd/repositories/TimeRepository.java
@@ -4,6 +4,12 @@ import com.ufape.projetobanquinhobd.entities.Time;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface TimeRepository extends JpaRepository<Time, Long> {
+    List<Time> findByTreinadorId(Long treinadorId);
+    Optional<Time> findByIdAndTreinadorId(Long id, Long treinadorId);
+    boolean existsByPokemons_Id(Long pokemonId);
 }

--- a/backend/src/main/java/com/ufape/projetobanquinhobd/repositories/TorneioRepository.java
+++ b/backend/src/main/java/com/ufape/projetobanquinhobd/repositories/TorneioRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TorneioRepository extends JpaRepository<Torneio, Long> {
+    boolean existsByTimes_Id(Long timeId);
 }

--- a/backend/src/main/java/com/ufape/projetobanquinhobd/services/PokemonService.java
+++ b/backend/src/main/java/com/ufape/projetobanquinhobd/services/PokemonService.java
@@ -1,17 +1,40 @@
 package com.ufape.projetobanquinhobd.services;
 
+import com.ufape.projetobanquinhobd.entities.Especie;
 import com.ufape.projetobanquinhobd.entities.Pokemon;
+import com.ufape.projetobanquinhobd.entities.Ataque;
+import com.ufape.projetobanquinhobd.entities.Treinador;
+import com.ufape.projetobanquinhobd.repositories.AtaqueRepository;
+import com.ufape.projetobanquinhobd.repositories.EspecieRepository;
 import com.ufape.projetobanquinhobd.repositories.PokemonRepository;
+import com.ufape.projetobanquinhobd.repositories.TimeRepository;
+import com.ufape.projetobanquinhobd.repositories.TreinadorRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 public class PokemonService {
     @Autowired
     private PokemonRepository pokemonRepository;
+
+    @Autowired
+    private TreinadorRepository treinadorRepository;
+
+    @Autowired
+    private EspecieRepository especieRepository;
+
+    @Autowired
+    private TimeRepository timeRepository;
+
+    @Autowired
+    private AtaqueRepository ataqueRepository;
 
     public Pokemon salvar(Pokemon pokemon) {
         return pokemonRepository.save(pokemon);
@@ -21,8 +44,25 @@ public class PokemonService {
         return pokemonRepository.findAll();
     }
 
+    public List<Pokemon> listarPorTreinador(Long treinadorId) {
+        validarTreinadorExiste(treinadorId);
+        return pokemonRepository.findByTreinadorId(treinadorId);
+    }
+
     public Optional<Pokemon> buscarPorId(Long id) {
         return pokemonRepository.findById(id);
+    }
+
+    public Pokemon criarParaTreinador(Long treinadorId, String apelido, String especieNome) {
+        Treinador treinador = treinadorRepository.findById(treinadorId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Treinador não encontrado: " + treinadorId));
+
+        Especie especie = buscarEspecie(especieNome);
+        String apelidoDefinido = (apelido == null || apelido.isBlank()) ? especie.getNome() : apelido;
+
+        Pokemon pokemon = new Pokemon(apelidoDefinido, especie, treinador);
+        return pokemonRepository.save(pokemon);
     }
 
     public Pokemon atualizar(Long id, Pokemon pokemonAtualizado) {
@@ -36,7 +76,125 @@ public class PokemonService {
             .orElseThrow(() -> new RuntimeException("Pokemon não encontrado com id: " + id));
     }
 
+    public Pokemon atualizarParaTreinador(Long treinadorId, Long pokemonId, String apelido, String especieNome) {
+        Pokemon pokemon = pokemonRepository.findByIdAndTreinadorId(pokemonId, treinadorId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Pokémon não encontrado para este treinador"));
+
+        if (apelido != null) {
+            if (apelido.isBlank()) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Apelido é obrigatório");
+            }
+            pokemon.setApelido(apelido);
+        }
+
+        if (especieNome != null) {
+            Especie especie = buscarEspecie(especieNome);
+            pokemon.setEspecie(especie);
+        }
+
+        return pokemonRepository.save(pokemon);
+    }
+
     public void deletarPorId(Long id) {
         pokemonRepository.deleteById(id);
+    }
+
+    public void removerParaTreinador(Long treinadorId, Long pokemonId) {
+        Pokemon pokemon = pokemonRepository.findByIdAndTreinadorId(pokemonId, treinadorId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Pokémon não encontrado para este treinador"));
+
+        if (timeRepository.existsByPokemons_Id(pokemonId)) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "Não é possível remover este pokémon porque ele está em um time. " +
+                            "Remova o pokémon do time primeiro."
+            );
+        }
+
+        pokemonRepository.delete(pokemon);
+    }
+
+    public Set<Ataque> listarAtaquesDoPokemon(Long treinadorId, Long pokemonId) {
+        Pokemon pokemon = buscarPokemonDoTreinador(treinadorId, pokemonId);
+        return pokemon.getAtaques();
+    }
+
+    public Pokemon definirAtaquesDoPokemon(Long treinadorId, Long pokemonId, List<String> ataquesNomes) {
+        Pokemon pokemon = buscarPokemonDoTreinador(treinadorId, pokemonId);
+
+        if (ataquesNomes == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Lista de ataques é obrigatória");
+        }
+
+        if (ataquesNomes.size() > 4) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Um pokémon pode ter no máximo 4 ataques");
+        }
+
+        Set<Ataque> ataques = ataquesNomes.stream()
+                .map(this::buscarAtaque)
+                .collect(Collectors.toSet());
+
+        pokemon.getAtaques().clear();
+        pokemon.getAtaques().addAll(ataques);
+        return pokemonRepository.save(pokemon);
+    }
+
+    public Pokemon adicionarAtaqueAoPokemon(Long treinadorId, Long pokemonId, String ataqueNome) {
+        Pokemon pokemon = buscarPokemonDoTreinador(treinadorId, pokemonId);
+        Ataque ataque = buscarAtaque(ataqueNome);
+
+        if (pokemon.getAtaques().size() >= 4 && !pokemon.getAtaques().contains(ataque)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Um pokémon pode ter no máximo 4 ataques");
+        }
+
+        pokemon.getAtaques().add(ataque);
+        return pokemonRepository.save(pokemon);
+    }
+
+    public Pokemon removerAtaqueDoPokemon(Long treinadorId, Long pokemonId, String ataqueNome) {
+        Pokemon pokemon = buscarPokemonDoTreinador(treinadorId, pokemonId);
+        Ataque ataque = buscarAtaque(ataqueNome);
+
+        pokemon.getAtaques().remove(ataque);
+        return pokemonRepository.save(pokemon);
+    }
+
+    private void validarTreinadorExiste(Long treinadorId) {
+        if (!treinadorRepository.existsById(treinadorId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+                    "Treinador não encontrado: " + treinadorId);
+        }
+    }
+
+    private Especie buscarEspecie(String especieNome) {
+        if (especieNome == null || especieNome.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Espécie é obrigatória");
+        }
+
+        return especieRepository.findById(especieNome)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Espécie não encontrada: " + especieNome));
+    }
+
+    private Pokemon buscarPokemonDoTreinador(Long treinadorId, Long pokemonId) {
+        validarTreinadorExiste(treinadorId);
+        return pokemonRepository.findByIdAndTreinadorId(pokemonId, treinadorId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Pokémon não encontrado para este treinador"));
+    }
+
+    private Ataque buscarAtaque(String ataqueNome) {
+        if (ataqueNome == null || ataqueNome.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Nome do ataque é obrigatório");
+        }
+
+        return ataqueRepository.findById(ataqueNome)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Ataque não encontrado: " + ataqueNome));
     }
 }

--- a/backend/src/main/java/com/ufape/projetobanquinhobd/services/TimeService.java
+++ b/backend/src/main/java/com/ufape/projetobanquinhobd/services/TimeService.java
@@ -1,17 +1,35 @@
 package com.ufape.projetobanquinhobd.services;
 
+import com.ufape.projetobanquinhobd.entities.Pokemon;
 import com.ufape.projetobanquinhobd.entities.Time;
+import com.ufape.projetobanquinhobd.entities.Treinador;
+import com.ufape.projetobanquinhobd.repositories.PokemonRepository;
 import com.ufape.projetobanquinhobd.repositories.TimeRepository;
+import com.ufape.projetobanquinhobd.repositories.TorneioRepository;
+import com.ufape.projetobanquinhobd.repositories.TreinadorRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 public class TimeService {
     @Autowired
     private TimeRepository timeRepository;
+
+    @Autowired
+    private TreinadorRepository treinadorRepository;
+
+    @Autowired
+    private PokemonRepository pokemonRepository;
+
+    @Autowired
+    private TorneioRepository torneioRepository;
 
     public Time salvar(Time time) {
         return timeRepository.save(time);
@@ -21,8 +39,23 @@ public class TimeService {
         return timeRepository.findAll();
     }
 
+    public List<Time> listarPorTreinador(Long treinadorId) {
+        validarTreinadorExiste(treinadorId);
+        return timeRepository.findByTreinadorId(treinadorId);
+    }
+
     public Optional<Time> buscarPorId(Long id) {
         return timeRepository.findById(id);
+    }
+
+    public Time criarParaTreinador(Long treinadorId, String nome, List<Long> pokemonIds) {
+        Treinador treinador = treinadorRepository.findById(treinadorId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Treinador não encontrado: " + treinadorId));
+
+        Time time = new Time(nome, treinador);
+        sincronizarPokemons(time, pokemonIds, treinador);
+        return timeRepository.save(time);
     }
 
     public Time atualizar(Long id, Time timeAtualizado) {
@@ -35,7 +68,70 @@ public class TimeService {
             .orElseThrow(() -> new RuntimeException("Time não encontrado com id: " + id));
     }
 
+    public Time atualizarParaTreinador(Long treinadorId, Long timeId, String nome, List<Long> pokemonIds) {
+        Time time = timeRepository.findByIdAndTreinadorId(timeId, treinadorId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Time não encontrado para este treinador"));
+
+        if (nome != null) {
+            if (nome.isBlank()) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Nome do time é obrigatório");
+            }
+            time.setNome(nome);
+        }
+
+        Treinador treinador = time.getTreinador();
+        sincronizarPokemons(time, pokemonIds, treinador);
+
+        return timeRepository.save(time);
+    }
+
     public void deletarPorId(Long id) {
         timeRepository.deleteById(id);
+    }
+
+    public void removerParaTreinador(Long treinadorId, Long timeId) {
+        Time time = timeRepository.findByIdAndTreinadorId(timeId, treinadorId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Time não encontrado para este treinador"));
+
+        if (torneioRepository.existsByTimes_Id(timeId)) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "Não é possível remover este time porque ele está inscrito em um torneio. " +
+                            "Remova o time do torneio primeiro."
+            );
+        }
+
+        timeRepository.delete(time);
+    }
+
+    private void validarTreinadorExiste(Long treinadorId) {
+        if (!treinadorRepository.existsById(treinadorId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+                    "Treinador não encontrado: " + treinadorId);
+        }
+    }
+
+    private void sincronizarPokemons(Time time, List<Long> pokemonIds, Treinador treinador) {
+        if (pokemonIds == null) {
+            return;
+        }
+
+        if (pokemonIds.size() > 6) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Um time pode ter no máximo 6 pokémons");
+        }
+
+        Set<Pokemon> pokemons = pokemonRepository.findAllById(pokemonIds).stream()
+                .peek(pokemon -> {
+                    if (!pokemon.getTreinador().getId().equals(treinador.getId())) {
+                        throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                                "Pokémon " + pokemon.getId() + " não pertence ao treinador");
+                    }
+                })
+                .collect(Collectors.toSet());
+
+        time.getPokemons().clear();
+        time.getPokemons().addAll(pokemons);
     }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -11,3 +11,5 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 
 jwt.secret=${JWT_SECRET:dev-secret-key-for-development-only-min-256-bits-required-change-in-production}
 jwt.expiration-ms=${JWT_EXPIRATION_MS:28800000}
+
+server.error.include-message=always

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -38,8 +38,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "4kB",
-                  "maximumError": "8kB"
+                  "maximumWarning": "50kB",
+                  "maximumError": "100kB"
                 }
               ],
               "outputHashing": "all"

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -30,6 +30,22 @@ export const routes: Routes = [
     canActivate: [authGuard],
   },
   {
+    path: 'pokemons',
+    loadComponent: () =>
+      import('./features/pokemon-manager/pokemon-manager.component').then(
+        (m) => m.PokemonManagerComponent,
+      ),
+    canActivate: [authGuard],
+  },
+  {
+    path: 'times',
+    loadComponent: () =>
+      import('./features/time-manager/time-manager.component').then(
+        (m) => m.TimeManagerComponent,
+      ),
+    canActivate: [authGuard],
+  },
+  {
     path: 'tournament/:id',
     loadComponent: () =>
       import('./features/tournament-view/tournament-view.component').then(

--- a/frontend/src/app/core/services/catalogo.service.ts
+++ b/frontend/src/app/core/services/catalogo.service.ts
@@ -2,12 +2,13 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { Especie, Tipo, Ataque } from '../models';
+import { environment } from '../../../environments/environment';
 
 @Injectable({
   providedIn: 'root'
 })
 export class CatalogoService {
-  private apiUrl = 'http://localhost:8080/api/catalogo';
+  private apiUrl = `${environment.apiUrl}/catalogo`;
 
   constructor(private http: HttpClient) {}
 

--- a/frontend/src/app/core/services/treinador.service.ts
+++ b/frontend/src/app/core/services/treinador.service.ts
@@ -1,13 +1,14 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { Treinador, Time, Pokemon } from '../models';
+import { Treinador, Time, Pokemon, Ataque } from '../models';
+import { environment } from '../../../environments/environment';
 
 @Injectable({
   providedIn: 'root'
 })
 export class TreinadorService {
-  private apiUrl = 'http://localhost:8080/api/treinadores';
+  private apiUrl = `${environment.apiUrl}/treinadores`;
 
   constructor(private http: HttpClient) {}
 
@@ -41,6 +42,10 @@ export class TreinadorService {
     return this.http.get<Time[]>(`${this.apiUrl}/times`);
   }
 
+  listarTimesDoTreinador(treinadorId: number): Observable<Time[]> {
+    return this.http.get<Time[]>(`${this.apiUrl}/${treinadorId}/times`);
+  }
+
   buscarTime(id: number): Observable<Time> {
     return this.http.get<Time>(`${this.apiUrl}/times/${id}`);
   }
@@ -57,24 +62,98 @@ export class TreinadorService {
     return this.http.delete<void>(`${this.apiUrl}/times/${id}`);
   }
 
+  criarTimeParaTreinador(
+    treinadorId: number,
+    payload: { nome: string; pokemonIds?: number[] },
+  ): Observable<Time> {
+    return this.http.post<Time>(`${this.apiUrl}/${treinadorId}/times`, payload);
+  }
+
+  atualizarTimeDoTreinador(
+    treinadorId: number,
+    timeId: number,
+    payload: { nome?: string; pokemonIds?: number[] },
+  ): Observable<Time> {
+    return this.http.put<Time>(
+      `${this.apiUrl}/${treinadorId}/times/${timeId}`,
+      payload,
+    );
+  }
+
+  deletarTimeDoTreinador(treinadorId: number, timeId: number): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/${treinadorId}/times/${timeId}`);
+  }
+
   // Métodos para Pokemons
-  listarPokemons(): Observable<Pokemon[]> {
-    return this.http.get<Pokemon[]>(`${this.apiUrl}/pokemons`);
+  listarPokemonsDoTreinador(treinadorId: number): Observable<Pokemon[]> {
+    return this.http.get<Pokemon[]>(`${this.apiUrl}/${treinadorId}/pokemons`);
   }
 
-  buscarPokemon(id: number): Observable<Pokemon> {
-    return this.http.get<Pokemon>(`${this.apiUrl}/pokemons/${id}`);
+  criarPokemonParaTreinador(
+    treinadorId: number,
+    payload: { apelido?: string | null; especieNome: string },
+  ): Observable<Pokemon> {
+    return this.http.post<Pokemon>(
+      `${this.apiUrl}/${treinadorId}/pokemons`,
+      payload,
+    );
   }
 
-  criarPokemon(pokemon: Pokemon): Observable<Pokemon> {
-    return this.http.post<Pokemon>(`${this.apiUrl}/pokemons`, pokemon);
+  atualizarPokemonDoTreinador(
+    treinadorId: number,
+    pokemonId: number,
+    payload: { apelido?: string | null; especieNome?: string | null },
+  ): Observable<Pokemon> {
+    return this.http.put<Pokemon>(
+      `${this.apiUrl}/${treinadorId}/pokemons/${pokemonId}`,
+      payload,
+    );
   }
 
-  atualizarPokemon(id: number, pokemon: Pokemon): Observable<Pokemon> {
-    return this.http.put<Pokemon>(`${this.apiUrl}/pokemons/${id}`, pokemon);
+  deletarPokemonDoTreinador(
+    treinadorId: number,
+    pokemonId: number,
+  ): Observable<void> {
+    return this.http.delete<void>(
+      `${this.apiUrl}/${treinadorId}/pokemons/${pokemonId}`,
+    );
   }
 
-  deletarPokemon(id: number): Observable<void> {
-    return this.http.delete<void>(`${this.apiUrl}/pokemons/${id}`);
+  listarAtaquesDoPokemon(treinadorId: number, pokemonId: number): Observable<Ataque[]> {
+    return this.http.get<Ataque[]>(
+      `${this.apiUrl}/${treinadorId}/pokemons/${pokemonId}/ataques`,
+    );
+  }
+
+  definirAtaquesDoPokemon(
+    treinadorId: number,
+    pokemonId: number,
+    ataquesNomes: string[],
+  ): Observable<Pokemon> {
+    return this.http.put<Pokemon>(
+      `${this.apiUrl}/${treinadorId}/pokemons/${pokemonId}/ataques`,
+      { ataquesNomes },
+    );
+  }
+
+  adicionarAtaqueAoPokemon(
+    treinadorId: number,
+    pokemonId: number,
+    ataqueNome: string,
+  ): Observable<Pokemon> {
+    return this.http.post<Pokemon>(
+      `${this.apiUrl}/${treinadorId}/pokemons/${pokemonId}/ataques/${encodeURIComponent(ataqueNome)}`,
+      {},
+    );
+  }
+
+  removerAtaqueDoPokemon(
+    treinadorId: number,
+    pokemonId: number,
+    ataqueNome: string,
+  ): Observable<Pokemon> {
+    return this.http.delete<Pokemon>(
+      `${this.apiUrl}/${treinadorId}/pokemons/${pokemonId}/ataques/${encodeURIComponent(ataqueNome)}`,
+    );
   }
 }

--- a/frontend/src/app/features/home/home.component.css
+++ b/frontend/src/app/features/home/home.component.css
@@ -312,6 +312,14 @@ body, html {
   gap: 20px;
 }
 
+.content-header-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
 .content-title {
   font-family: 'Press Start 2P', monospace;
   font-size: 24px;
@@ -339,6 +347,60 @@ body, html {
   color: #777;
   letter-spacing: 0.5px;
   margin: 8px 0 0;
+}
+
+.btn-manage-pokemons {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: linear-gradient(135deg, #ffde59, #ffb347);
+  color: #1a1a1a;
+  border: 3px solid #1a1a1a;
+  border-radius: 12px;
+  padding: 12px 16px;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 11px;
+  cursor: pointer;
+  box-shadow: 0 6px 0 #1a1a1a;
+  transition: transform 0.08s ease, box-shadow 0.08s ease;
+}
+
+.btn-manage-pokemons img {
+  width: 22px;
+  height: 22px;
+  image-rendering: pixelated;
+}
+
+.btn-manage-pokemons:active {
+  transform: translateY(2px);
+  box-shadow: 0 2px 0 #1a1a1a;
+}
+
+.btn-manage-times {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: linear-gradient(135deg, #64b5f6, #42a5f5);
+  color: #1a1a1a;
+  border: 3px solid #1a1a1a;
+  border-radius: 12px;
+  padding: 12px 16px;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 11px;
+  cursor: pointer;
+  box-shadow: 0 6px 0 #1a1a1a;
+  transition: transform 0.08s ease, box-shadow 0.08s ease;
+}
+
+.btn-manage-times img {
+  width: 22px;
+  height: 22px;
+  image-rendering: pixelated;
+}
+
+.btn-manage-times:active {
+  transform: translateY(2px);
+  box-shadow: 0 2px 0 #1a1a1a;
 }
 
 /* ---- TOURNAMENTS SECTION ---- */
@@ -2668,4 +2730,3 @@ body, html {
   border-radius: 12px;
   font-size: 0.78rem;
 }
-

--- a/frontend/src/app/features/home/home.component.html
+++ b/frontend/src/app/features/home/home.component.html
@@ -82,10 +82,22 @@
       <!-- Tournaments Tab -->
       <section class="tab-content" *ngIf="isTabActive('tournaments')">
         <div class="content-card">
-          <h2 class="content-title">Torneios</h2>
-          <p class="content-subtitle">
-            Encontre e participe de torneios incríveis!
-          </p>
+          <div class="content-header-row">
+            <div>
+              <h2 class="content-title">Torneios</h2>
+              <p class="content-subtitle">
+                Encontre e participe de torneios incríveis!
+              </p>
+            </div>
+            <button class="btn-manage-pokemons" (click)="goToPokemons()">
+              <img src="/icons/poke-ball.png" alt="Pokemons" />
+              Meus Pokemons
+            </button>
+            <button class="btn-manage-times" (click)="goToTimes()">
+              <img src="/icons/poke-ball.png" alt="Times" />
+              Meus Times
+            </button>
+          </div>
 
           <!-- Loading State -->
           <div *ngIf="loadingTorneios" class="tournaments-loading">

--- a/frontend/src/app/features/home/home.component.ts
+++ b/frontend/src/app/features/home/home.component.ts
@@ -526,6 +526,14 @@ export class HomeComponent implements OnInit {
     this.router.navigate(['/edit-profile']);
   }
 
+  goToPokemons(): void {
+    this.router.navigate(['/pokemons']);
+  }
+
+  goToTimes(): void {
+    this.router.navigate(['/times']);
+  }
+
   // ─── Torneio Actions ─────────────────────────────────────────────────────────
 
   inscreverNoTorneio(torneio: Torneio): void {

--- a/frontend/src/app/features/pokemon-manager/pokemon-manager.component.css
+++ b/frontend/src/app/features/pokemon-manager/pokemon-manager.component.css
@@ -1,0 +1,574 @@
+* {
+  box-sizing: border-box;
+}
+
+.pokemon-page {
+  position: relative;
+  width: 100vw;
+  min-height: 100vh;
+  font-family: 'Nunito', 'Segoe UI', sans-serif;
+  overflow-x: hidden;
+  padding-bottom: 40px;
+}
+
+.bg-sky {
+  position: fixed;
+  inset: 0;
+  background-image:
+    linear-gradient(180deg, rgba(0, 0, 0, 0.08) 0%, rgba(0, 0, 0, 0.06) 100%),
+    url('/images/city-pk.png');
+  background-size: cover;
+  background-position: center;
+  background-attachment: fixed;
+  z-index: -1;
+}
+
+.page-header {
+  background: linear-gradient(135deg, #f8f8f3 0%, #f0f0eb 100%);
+  border-bottom: 4px solid #1a1a1a;
+  box-shadow:
+    0 8px 16px rgba(0, 0, 0, 0.25),
+    0 4px 8px rgba(0, 0, 0, 0.15),
+    inset 0 1px 0 rgba(255, 255, 255, 0.5);
+  padding: 16px 24px;
+}
+
+.header-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.header-logo {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.logo-img {
+  width: 56px;
+  height: 56px;
+  object-fit: contain;
+  image-rendering: pixelated;
+}
+
+.logo-text h1 {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 18px;
+  color: #cc2200;
+  text-shadow: 2px 2px 0 #9a1800;
+  margin: 0;
+}
+
+.logo-text p {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 9px;
+  color: #1a5fb4;
+  margin: 4px 0 0;
+  letter-spacing: 1px;
+}
+
+.header-user {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 16px;
+  background: linear-gradient(145deg, #ffffff, #f5f5f5);
+  border: 3px solid #1a1a1a;
+  border-radius: 8px;
+  box-shadow: 4px 4px 0 #1a1a1a;
+}
+
+.user-name {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 10px;
+  color: #1a1a1a;
+}
+
+.user-email {
+  font-family: 'Nunito', sans-serif;
+  font-size: 12px;
+  color: #777;
+  border-left: 2px solid #1a1a1a;
+  padding-left: 12px;
+}
+
+.btn-back {
+  background: linear-gradient(145deg, #1a5fb4, #1976d2);
+  color: #fff;
+  border: 2px solid #1a1a1a;
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 8px;
+  cursor: pointer;
+  box-shadow: 2px 2px 0 #0f3d7a;
+}
+
+.page-main {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.hero-card {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+  gap: 24px;
+  background: linear-gradient(145deg, #f8f8f3, #f0f0eb);
+  border: 4px solid #1a1a1a;
+  border-top: 6px solid #cc2200;
+  border-radius: 12px;
+  padding: 28px;
+  margin-bottom: 24px;
+  box-shadow: 12px 12px 0 #1a1a1a;
+}
+
+.hero-copy h2 {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 20px;
+  color: #cc2200;
+  margin: 0 0 12px;
+}
+
+.hero-copy p {
+  font-size: 14px;
+  color: #555;
+  line-height: 1.6;
+}
+
+.hero-stats {
+  display: flex;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.chip {
+  background: linear-gradient(145deg, #e3f2fd, #bbdefb);
+  border: 3px solid #1a5fb4;
+  border-radius: 8px;
+  padding: 10px 14px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  box-shadow: 2px 2px 0 #1a5fb4;
+}
+
+.chip-label {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 8px;
+  color: #1a5fb4;
+}
+
+.chip strong {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 14px;
+  color: #cc2200;
+}
+
+.hero-illustration {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.hero-illustration img {
+  max-width: 220px;
+  image-rendering: pixelated;
+}
+
+.manager-grid {
+  display: grid;
+  grid-template-columns: 360px 1fr;
+  gap: 24px;
+}
+
+.card {
+  background: linear-gradient(145deg, #f8f8f3, #f0f0eb);
+  border: 4px solid #1a1a1a;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 8px 8px 0 #1a1a1a;
+}
+
+.card-title h3,
+.card-header h3 {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 14px;
+  color: #cc2200;
+  margin: 0 0 8px;
+}
+
+.card-title p,
+.card-header p {
+  font-size: 13px;
+  color: #666;
+  margin: 0;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 14px;
+  margin-bottom: 18px;
+  flex-wrap: wrap;
+}
+
+.field {
+  margin-top: 18px;
+}
+
+.field label {
+  display: block;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 9px;
+  margin-bottom: 8px;
+}
+
+.field input,
+.field select,
+.search-box input {
+  width: 100%;
+  background: #fff;
+  border: 3px solid #1a1a1a;
+  border-radius: 8px;
+  padding: 12px;
+  font-size: 14px;
+  box-shadow: 2px 2px 0 #1a1a1a;
+}
+
+.search-box input {
+  border-width: 2px;
+  padding: 10px 12px;
+  font-size: 13px;
+}
+
+.actions {
+  margin-top: 18px;
+}
+
+.btn {
+  padding: 10px 14px;
+  border: 3px solid #1a1a1a;
+  border-radius: 8px;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 8px;
+  cursor: pointer;
+  box-shadow: 3px 3px 0 #1a1a1a;
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background: linear-gradient(145deg, #cc2200, #e63900);
+  color: #fff;
+}
+
+.btn-ghost {
+  background: linear-gradient(145deg, #ffffff, #f5f5f5);
+  color: #1a1a1a;
+}
+
+.btn-danger {
+  background: linear-gradient(145deg, #ff6b6b, #d00000);
+  color: #fff;
+}
+
+.loading-state,
+.empty-state {
+  padding: 28px 16px;
+  text-align: center;
+  background: linear-gradient(145deg, #ffffff, #f8f8f8);
+  border: 3px dashed #1a5fb4;
+  border-radius: 8px;
+}
+
+.loading-state p,
+.empty-state p {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 10px;
+  margin: 0;
+}
+
+.empty-icon img {
+  width: 64px;
+  height: 64px;
+  opacity: 0.5;
+}
+
+.pokemon-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+  gap: 14px;
+}
+
+.pokemon-card {
+  min-width: 0;
+  background: linear-gradient(145deg, #ffffff, #f8f8f8);
+  border: 3px solid #1a1a1a;
+  border-radius: 10px;
+  padding: 12px;
+  box-shadow: 4px 4px 0 #1a1a1a;
+}
+
+.pokemon-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+}
+
+.pokemon-id,
+.pokemon-species {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 8px;
+  min-width: 0;
+}
+
+.pokemon-species {
+  color: #1a5fb4;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.pokemon-body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  margin: 12px 0;
+}
+
+.pokemon-body img {
+  width: 72px;
+  height: 72px;
+  object-fit: contain;
+  image-rendering: pixelated;
+}
+
+.pokemon-body h4 {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 9px;
+  margin: 0;
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.attack-count {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 7px;
+  color: #666;
+}
+
+.pokemon-actions,
+.edit-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.error-message {
+  margin-top: 12px;
+  padding: 10px 14px;
+  background: linear-gradient(145deg, #ffebee, #ffcdd2);
+  border: 2px solid #d32f2f;
+  border-radius: 6px;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 8px;
+  color: #c62828;
+}
+
+.attack-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.attack-header h4 {
+  margin: 0;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 10px;
+  color: #cc2200;
+}
+
+.attack-selected {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 8px;
+  color: #1a5fb4;
+}
+
+.attack-hint {
+  margin: 10px 0 12px;
+  font-size: 12px;
+  color: #555;
+}
+
+.attack-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 10px;
+}
+
+.attack-option {
+  text-align: left;
+  border: 2px solid #1a1a1a;
+  border-radius: 8px;
+  background: linear-gradient(145deg, #ffffff, #f6f6f6);
+  padding: 10px;
+  cursor: pointer;
+  box-shadow: 2px 2px 0 #1a1a1a;
+}
+
+.attack-option.selected {
+  border-color: #1a5fb4;
+  box-shadow: 2px 2px 0 #1a5fb4;
+  background: linear-gradient(145deg, #e8f2ff, #d8eaff);
+}
+
+.attack-name {
+  display: block;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 7px;
+  color: #1a1a1a;
+  margin-bottom: 6px;
+}
+
+.attack-meta {
+  display: block;
+  font-size: 11px;
+  color: #666;
+}
+
+.attack-actions {
+  margin-top: 12px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.edit-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(26, 95, 180, 0.28), transparent 45%),
+    radial-gradient(circle at 80% 80%, rgba(204, 34, 0, 0.3), transparent 48%),
+    rgba(7, 10, 18, 0.72);
+  backdrop-filter: blur(4px);
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.edit-modal {
+  width: min(980px, 100%);
+  max-height: calc(100vh - 48px);
+  overflow: auto;
+  background: linear-gradient(145deg, #f8f8f3, #f0f0eb);
+  border: 4px solid #1a1a1a;
+  border-top: 6px solid #cc2200;
+  border-radius: 14px;
+  box-shadow: 14px 14px 0 #1a1a1a;
+  padding: 24px;
+}
+
+.edit-hero {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 16px;
+  align-items: center;
+  padding-bottom: 14px;
+  border-bottom: 2px solid #d9d9d9;
+}
+
+.edit-hero img {
+  width: 120px;
+  height: 120px;
+  object-fit: contain;
+  image-rendering: pixelated;
+  filter: drop-shadow(3px 3px 0 rgba(0, 0, 0, 0.25));
+}
+
+.edit-hero h3 {
+  margin: 0;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 12px;
+  color: #cc2200;
+}
+
+.edit-hero p {
+  margin: 8px 0 0;
+  color: #555;
+  font-size: 13px;
+}
+
+.edit-content {
+  margin-top: 12px;
+}
+
+.edit-content .field {
+  margin-top: 14px;
+}
+
+@media (max-width: 1024px) {
+  .manager-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-card {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .header-content {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .header-user {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .page-main {
+    padding: 16px;
+  }
+
+  .hero-card,
+  .card {
+    padding: 16px;
+  }
+
+  .pokemon-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .edit-overlay {
+    padding: 12px;
+  }
+
+  .edit-modal {
+    padding: 16px;
+  }
+
+  .edit-hero {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .edit-hero img {
+    margin: 0 auto;
+  }
+}

--- a/frontend/src/app/features/pokemon-manager/pokemon-manager.component.html
+++ b/frontend/src/app/features/pokemon-manager/pokemon-manager.component.html
@@ -1,0 +1,205 @@
+<div class="pokemon-page">
+  <div class="bg-sky"></div>
+
+  <header class="page-header">
+    <div class="header-content">
+      <div class="header-logo">
+        <img src="/icons/poke-ball.png" alt="Pokemon" class="logo-img" />
+        <div class="logo-text">
+          <h1>Meus Pokemons</h1>
+          <p>Gerencie sua box de batalha</p>
+        </div>
+      </div>
+
+      <div class="header-user">
+        <span class="user-name">{{ currentUser?.nome }}</span>
+        <span class="user-email">{{ currentUser?.email }}</span>
+        <button class="btn-back" (click)="goHome()">Voltar</button>
+      </div>
+    </div>
+  </header>
+
+  <div class="page-main">
+    <section class="hero-card">
+      <div class="hero-copy">
+        <h2>Organize sua Box</h2>
+        <p>
+          Crie, edite e remova pokemons do seu treinador. Escolha a especie,
+          defina apelidos e deixe sua colecao pronta para montar times.
+        </p>
+        <div class="hero-stats">
+          <div class="chip">
+            <span class="chip-label">Pokemons</span>
+            <strong>{{ pokemons.length }}</strong>
+          </div>
+          <div class="chip">
+            <span class="chip-label">Especies</span>
+            <strong>{{ especies.length }}</strong>
+          </div>
+        </div>
+      </div>
+      <div class="hero-illustration">
+        <img src="/images/pokemon-header.gif" alt="Pokemon" />
+      </div>
+    </section>
+
+    <div class="manager-grid">
+      <div class="card form-card">
+        <div class="card-title">
+          <h3>Novo Pokemon</h3>
+          <p>Escolha a especie e opcionalmente um apelido.</p>
+        </div>
+
+        <div class="field">
+          <label for="especie-nome">Especie</label>
+          <select
+            id="especie-nome"
+            [(ngModel)]="newPokemon.especieNome"
+            [disabled]="loadingEspecies"
+          >
+            <option value="" disabled>
+              {{ loadingEspecies ? 'Carregando especies...' : 'Selecione uma especie' }}
+            </option>
+            <option *ngFor="let especie of especies" [value]="especie.nome">
+              {{ especie.nome }}
+            </option>
+          </select>
+        </div>
+
+        <div class="field">
+          <label for="pokemon-apelido">Apelido (opcional)</label>
+          <input
+            id="pokemon-apelido"
+            type="text"
+            maxlength="60"
+            placeholder="Ex: Relampago, Tanque, Ninja..."
+            [(ngModel)]="newPokemon.apelido"
+          />
+        </div>
+
+        <div class="actions">
+          <button
+            class="btn btn-primary"
+            (click)="criarPokemon()"
+            [disabled]="savingPokemon || !newPokemon.especieNome"
+          >
+            {{ savingPokemon ? 'Criando...' : 'Adicionar Pokemon' }}
+          </button>
+        </div>
+
+        <p class="error-message" *ngIf="errorMessage">{{ errorMessage }}</p>
+      </div>
+
+      <div class="card list-card">
+        <div class="card-header">
+          <div>
+            <h3>Sua Box</h3>
+            <p>Visualize, pesquise e edite seus pokemons.</p>
+          </div>
+          <div class="search-box">
+            <input
+              type="text"
+              placeholder="Buscar por apelido ou especie..."
+              [(ngModel)]="searchPokemon"
+            />
+          </div>
+        </div>
+
+        <div class="loading-state" *ngIf="loadingPokemons">
+          <p>Carregando pokemons...</p>
+        </div>
+
+        <div class="empty-state" *ngIf="!loadingPokemons && filteredPokemons.length === 0">
+          <div class="empty-icon">
+            <img src="/icons/poke-ball.png" alt="Empty" />
+          </div>
+          <p>Nenhum pokemon encontrado</p>
+          <small>Adicione seu primeiro pokemon no painel ao lado.</small>
+        </div>
+
+        <div class="pokemon-grid" *ngIf="!loadingPokemons && filteredPokemons.length > 0">
+          <div class="pokemon-card" *ngFor="let pokemon of filteredPokemons">
+            <div class="pokemon-top">
+              <span class="pokemon-id">#{{ pokemon.id }}</span>
+              <span class="pokemon-species">{{ pokemon.especie.nome }}</span>
+            </div>
+
+            <div class="pokemon-body">
+              <img [src]="imageFor(pokemon)" [alt]="pokemon.especie.nome" />
+              <h4>{{ pokemon.apelido || pokemon.especie.nome }}</h4>
+              <small class="attack-count">{{ (pokemon.ataques || []).length }}/4 ataques</small>
+            </div>
+
+            <div class="pokemon-actions">
+              <button class="btn btn-ghost" (click)="iniciarEdicao($event, pokemon)">Editar</button>
+              <button
+                class="btn btn-danger"
+                (click)="removerPokemon($event, pokemon)"
+                [disabled]="deletingPokemonId === pokemon.id"
+              >
+                {{ deletingPokemonId === pokemon.id ? 'Removendo...' : 'Remover' }}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="edit-overlay" *ngIf="editingPokemon as pokemonSelecionado" (click)="cancelarEdicao()">
+    <div class="edit-modal" (click)="$event.stopPropagation()">
+      <div class="edit-hero">
+        <img [src]="imageFor(pokemonSelecionado)" [alt]="pokemonSelecionado.especie.nome" />
+        <div>
+          <h3>Editando {{ pokemonSelecionado.apelido || pokemonSelecionado.especie.nome }}</h3>
+          <p>Personalize especie, apelido e os 4 ataques do seu pokemon.</p>
+        </div>
+      </div>
+
+      <div class="edit-content">
+        <div class="field">
+          <label>Especie</label>
+          <select [(ngModel)]="editForm.especieNome">
+            <option *ngFor="let especie of especies" [value]="especie.nome">
+              {{ especie.nome }}
+            </option>
+          </select>
+        </div>
+
+        <div class="field">
+          <label>Apelido</label>
+          <input type="text" maxlength="60" [(ngModel)]="editForm.apelido" />
+        </div>
+
+        <div class="field">
+          <label>Ataques ({{ editForm.ataquesNomes.length }}/4)</label>
+          <p class="attack-hint">Clique para selecionar ou remover ataques.</p>
+
+          <div class="loading-state" *ngIf="loadingAtaques">
+            <p>Carregando ataques...</p>
+          </div>
+
+          <div class="attack-grid" *ngIf="!loadingAtaques">
+            <button
+              type="button"
+              class="attack-option"
+              *ngFor="let ataque of ataquesCatalogo"
+              [class.selected]="isAttackSelected(ataque.nome)"
+              (click)="toggleAttackSelection($event, ataque.nome)"
+            >
+              <span class="attack-name">{{ ataque.nome }}</span>
+              <span class="attack-meta">{{ ataque.tipo.nome }} · {{ ataque.categoria }}</span>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div class="edit-actions">
+        <button class="btn btn-ghost" (click)="cancelarEdicao()">Cancelar</button>
+        <button class="btn btn-primary" (click)="salvarEdicao()" [disabled]="savingPokemon">
+          {{ savingPokemon ? 'Salvando...' : 'Salvar alteracoes' }}
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/features/pokemon-manager/pokemon-manager.component.ts
+++ b/frontend/src/app/features/pokemon-manager/pokemon-manager.component.ts
@@ -1,0 +1,297 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { AuthService, User } from '../../core/services/auth.service';
+import { CatalogoService } from '../../core/services/catalogo.service';
+import { TreinadorService } from '../../core/services/treinador.service';
+import { Ataque, Especie, Pokemon } from '../../core/models';
+import { switchMap } from 'rxjs';
+
+@Component({
+  selector: 'app-pokemon-manager',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './pokemon-manager.component.html',
+  styleUrl: './pokemon-manager.component.css',
+})
+export class PokemonManagerComponent implements OnInit {
+  currentUser: User | null = null;
+  treinadorId?: number;
+
+  pokemons: Pokemon[] = [];
+  especies: Especie[] = [];
+  ataquesCatalogo: Ataque[] = [];
+
+  loadingPokemons = true;
+  loadingEspecies = true;
+  loadingAtaques = true;
+  savingPokemon = false;
+  deletingPokemonId: number | null = null;
+  editingPokemonId: number | null = null;
+  errorMessage = '';
+
+  searchPokemon = '';
+
+  newPokemon = {
+    apelido: '',
+    especieNome: '',
+  };
+
+  editForm = {
+    apelido: '',
+    especieNome: '',
+    ataquesNomes: [] as string[],
+  };
+
+  constructor(
+    private authService: AuthService,
+    private router: Router,
+    private treinadorService: TreinadorService,
+    private catalogoService: CatalogoService,
+  ) {}
+
+  ngOnInit(): void {
+    this.currentUser = this.authService.currentUser();
+    if (!this.currentUser) {
+      this.router.navigate(['/login']);
+      return;
+    }
+
+    this.treinadorId = this.currentUser.id;
+    this.loadEspecies();
+    this.loadAtaquesCatalogo();
+    this.loadPokemons();
+  }
+
+  get editingPokemon(): Pokemon | undefined {
+    if (this.editingPokemonId === null) return undefined;
+    return this.pokemons.find((pokemon) => pokemon.id === this.editingPokemonId);
+  }
+
+  get filteredPokemons(): Pokemon[] {
+    const term = this.searchPokemon.trim().toLowerCase();
+    if (!term) return this.pokemons;
+
+    return this.pokemons.filter((pokemon) => {
+      const apelido = (pokemon.apelido || '').toLowerCase();
+      const especie = (pokemon.especie?.nome || '').toLowerCase();
+      return apelido.includes(term) || especie.includes(term);
+    });
+  }
+
+  loadEspecies(): void {
+    this.loadingEspecies = true;
+    this.catalogoService.listarEspecies().subscribe({
+      next: (lista) => {
+        this.especies = lista;
+        this.loadingEspecies = false;
+
+        if (!this.newPokemon.especieNome && lista.length > 0) {
+          this.newPokemon.especieNome = lista[0].nome;
+        }
+      },
+      error: () => {
+        this.loadingEspecies = false;
+        this.errorMessage = 'Nao foi possivel carregar o catalogo de especies.';
+      },
+    });
+  }
+
+  loadPokemons(): void {
+    if (!this.treinadorId) return;
+
+    this.loadingPokemons = true;
+    this.errorMessage = '';
+
+    this.treinadorService.listarPokemonsDoTreinador(this.treinadorId).subscribe({
+      next: (lista) => {
+        this.pokemons = lista;
+        this.loadingPokemons = false;
+      },
+      error: () => {
+        this.loadingPokemons = false;
+        this.errorMessage = 'Nao foi possivel carregar seus pokemons.';
+      },
+    });
+  }
+
+  loadAtaquesCatalogo(): void {
+    this.loadingAtaques = true;
+    this.catalogoService.listarAtaques().subscribe({
+      next: (lista) => {
+        this.ataquesCatalogo = lista;
+        this.loadingAtaques = false;
+      },
+      error: () => {
+        this.loadingAtaques = false;
+        this.errorMessage = 'Nao foi possivel carregar os ataques do catalogo.';
+      },
+    });
+  }
+
+  criarPokemon(): void {
+    if (!this.treinadorId || this.savingPokemon) return;
+
+    const especieNome = this.newPokemon.especieNome.trim();
+    if (!especieNome) {
+      this.errorMessage = 'Selecione uma especie para criar o pokemon.';
+      return;
+    }
+
+    this.savingPokemon = true;
+    this.errorMessage = '';
+
+    this.treinadorService
+      .criarPokemonParaTreinador(this.treinadorId, {
+        apelido: this.newPokemon.apelido.trim() || null,
+        especieNome,
+      })
+      .subscribe({
+        next: (pokemon) => {
+          this.pokemons = [pokemon, ...this.pokemons];
+          this.newPokemon.apelido = '';
+          this.savingPokemon = false;
+        },
+        error: (err) => {
+          this.savingPokemon = false;
+          this.errorMessage = this.extractErrorMessage(
+            err,
+            'Nao foi possivel criar o pokemon agora.',
+          );
+        },
+      });
+  }
+
+  iniciarEdicao(event: Event, pokemon: Pokemon): void {
+    event.stopPropagation();
+    this.editingPokemonId = pokemon.id;
+    this.editForm = {
+      apelido: pokemon.apelido || '',
+      especieNome: pokemon.especie?.nome || '',
+      ataquesNomes: (pokemon.ataques || []).map((ataque) => ataque.nome),
+    };
+  }
+
+  cancelarEdicao(): void {
+    this.editingPokemonId = null;
+    this.editForm = { apelido: '', especieNome: '', ataquesNomes: [] };
+  }
+
+  salvarEdicao(): void {
+    if (!this.treinadorId || this.editingPokemonId === null || this.savingPokemon) return;
+
+    const apelido = this.editForm.apelido.trim();
+    const especieNome = this.editForm.especieNome.trim();
+
+    if (!apelido) {
+      this.errorMessage = 'O apelido do pokemon e obrigatorio.';
+      return;
+    }
+
+    if (!especieNome) {
+      this.errorMessage = 'Selecione uma especie valida.';
+      return;
+    }
+
+    this.savingPokemon = true;
+    this.errorMessage = '';
+
+    this.treinadorService
+      .atualizarPokemonDoTreinador(this.treinadorId, this.editingPokemonId, {
+        apelido,
+        especieNome,
+      })
+      .pipe(
+        switchMap(() =>
+          this.treinadorService.definirAtaquesDoPokemon(
+            this.treinadorId!,
+            this.editingPokemonId!,
+            this.editForm.ataquesNomes,
+          ),
+        ),
+      )
+      .subscribe({
+        next: (pokemonAtualizado) => {
+          this.pokemons = this.pokemons.map((p) =>
+            p.id === pokemonAtualizado.id ? pokemonAtualizado : p,
+          );
+          this.savingPokemon = false;
+          this.cancelarEdicao();
+        },
+        error: (err) => {
+          this.savingPokemon = false;
+          this.errorMessage = this.extractErrorMessage(
+            err,
+            'Nao foi possivel atualizar o pokemon.',
+          );
+        },
+      });
+  }
+
+  removerPokemon(event: Event, pokemon: Pokemon): void {
+    event.stopPropagation();
+    if (!this.treinadorId || this.deletingPokemonId) return;
+
+    const confirmDelete = confirm(`Liberar o pokemon "${pokemon.apelido}"?`);
+    if (!confirmDelete) return;
+
+    this.deletingPokemonId = pokemon.id;
+    this.errorMessage = '';
+
+    this.treinadorService
+      .deletarPokemonDoTreinador(this.treinadorId, pokemon.id)
+      .subscribe({
+        next: () => {
+          this.pokemons = this.pokemons.filter((p) => p.id !== pokemon.id);
+          this.deletingPokemonId = null;
+        },
+        error: (err) => {
+          this.deletingPokemonId = null;
+          this.errorMessage = this.extractErrorMessage(
+            err,
+            'Nao foi possivel remover o pokemon.',
+          );
+        },
+      });
+  }
+
+  isAttackSelected(ataqueNome: string): boolean {
+    return this.editForm.ataquesNomes.includes(ataqueNome);
+  }
+
+  toggleAttackSelection(event: Event, ataqueNome: string): void {
+    event.stopPropagation();
+    const alreadySelected = this.editForm.ataquesNomes.includes(ataqueNome);
+    if (alreadySelected) {
+      this.editForm.ataquesNomes = this.editForm.ataquesNomes.filter(
+        (nome) => nome !== ataqueNome,
+      );
+      return;
+    }
+
+    if (this.editForm.ataquesNomes.length >= 4) {
+      this.errorMessage = 'Um pokemon pode ter no maximo 4 ataques.';
+      return;
+    }
+
+    this.editForm.ataquesNomes = [...this.editForm.ataquesNomes, ataqueNome];
+  }
+
+  private extractErrorMessage(err: any, fallback: string): string {
+    return (
+      err?.error?.message ||
+      err?.error?.detail ||
+      err?.error?.error ||
+      fallback
+    );
+  }
+
+  imageFor(pokemon: Pokemon): string {
+    return pokemon.especie?.imagemUrl || '/images/pokemon-placeholder.png';
+  }
+
+  goHome(): void {
+    this.router.navigate(['/home']);
+  }
+}

--- a/frontend/src/app/features/time-manager/time-manager.component.css
+++ b/frontend/src/app/features/time-manager/time-manager.component.css
@@ -1,0 +1,749 @@
+/* ============================================
+   TIME MANAGER - RETRO PIXEL-ART STYLE
+   Following home.component.css patterns
+   ============================================ */
+
+* {
+  box-sizing: border-box;
+}
+
+.time-page {
+  position: relative;
+  width: 100vw;
+  min-height: 100vh;
+  font-family: 'Nunito', 'Segoe UI', sans-serif;
+  overflow-x: hidden;
+  padding-bottom: 40px;
+}
+
+/* ---- BACKGROUND ---- */
+.bg-sky {
+  position: fixed;
+  inset: 0;
+  background-image:
+    linear-gradient(180deg, rgba(0, 0, 0, 0.08) 0%, rgba(0, 0, 0, 0.06) 100%),
+    url('/images/city-pk.png');
+  background-size: cover;
+  background-position: center;
+  background-attachment: fixed;
+  z-index: -1;
+}
+
+/* ---- HEADER ---- */
+.page-header {
+  background: linear-gradient(135deg, #f8f8f3 0%, #f0f0eb 100%);
+  border-bottom: 4px solid #1a1a1a;
+  box-shadow: 
+    0 8px 16px rgba(0, 0, 0, 0.25),
+    0 4px 8px rgba(0, 0, 0, 0.15),
+    inset 0 1px 0 rgba(255, 255, 255, 0.5);
+  padding: 16px 24px;
+  z-index: 100;
+}
+
+.header-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.header-logo {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.logo-img {
+  width: 56px;
+  height: 56px;
+  object-fit: contain;
+  image-rendering: pixelated;
+}
+
+.logo-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.logo-text h1 {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 18px;
+  color: #cc2200;
+  text-shadow: 
+    2px 2px 0 #9a1800,
+    3px 3px 0 rgba(0, 0, 0, 0.2);
+  margin: 0;
+  letter-spacing: 1px;
+}
+
+.logo-text p {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 9px;
+  color: #1a5fb4;
+  margin: 2px 0 0;
+  letter-spacing: 2px;
+}
+
+.header-user {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 16px;
+  background: linear-gradient(145deg, #ffffff, #f5f5f5);
+  border: 3px solid #1a1a1a;
+  border-radius: 8px;
+  box-shadow: 
+    4px 4px 0 #1a1a1a,
+    inset 0 1px 0 rgba(255, 255, 255, 0.8);
+}
+
+.user-name {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 10px;
+  color: #1a1a1a;
+  letter-spacing: 0.5px;
+}
+
+.user-email {
+  font-family: 'Nunito', sans-serif;
+  font-size: 12px;
+  color: #777;
+  border-left: 2px solid #1a1a1a;
+  padding-left: 12px;
+}
+
+.btn-back {
+  background: linear-gradient(145deg, #1a5fb4, #1976d2);
+  color: #fff;
+  border: 2px solid #1a1a1a;
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 8px;
+  letter-spacing: 1px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  box-shadow: 2px 2px 0 #0f3d7a;
+}
+
+.btn-back:hover {
+  background: linear-gradient(145deg, #2266dd, #1a5fb4);
+  box-shadow: 3px 3px 0 #0f3d7a;
+  transform: translateY(-1px);
+}
+
+.btn-back:active {
+  transform: translate(1px, 1px);
+  box-shadow: 1px 1px 0 #0f3d7a;
+}
+
+/* ---- MAIN CONTENT ---- */
+.page-main {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+/* ---- HERO CARD ---- */
+.hero-card {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+  gap: 24px;
+  background: linear-gradient(145deg, #f8f8f3, #f0f0eb);
+  border: 4px solid #1a1a1a;
+  border-top: 6px solid #cc2200;
+  border-radius: 12px;
+  padding: 32px;
+  margin-bottom: 24px;
+  box-shadow: 
+    12px 12px 0 #1a1a1a,
+    0 20px 48px rgba(0, 0, 0, 0.25);
+}
+
+.hero-copy h2 {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 20px;
+  color: #cc2200;
+  text-shadow: 2px 2px 0 #9a1800;
+  margin: 0 0 12px;
+}
+
+.hero-copy p {
+  font-family: 'Nunito', sans-serif;
+  font-size: 14px;
+  color: #555;
+  line-height: 1.6;
+  margin: 0 0 16px;
+}
+
+.hero-stats {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.chip {
+  background: linear-gradient(145deg, #e3f2fd, #bbdefb);
+  border: 3px solid #1a5fb4;
+  border-radius: 8px;
+  padding: 12px 16px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  box-shadow: 2px 2px 0 #1a5fb4;
+}
+
+.chip-label {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 8px;
+  color: #1a5fb4;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.chip strong {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 16px;
+  color: #cc2200;
+}
+
+.hero-illustration {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.hero-illustration img {
+  max-width: 200px;
+  image-rendering: pixelated;
+  filter: drop-shadow(4px 4px 0 rgba(0, 0, 0, 0.2));
+}
+
+/* ---- MANAGER GRID ---- */
+.manager-grid {
+  display: grid;
+  grid-template-columns: 400px 1fr;
+  gap: 24px;
+}
+
+/* ---- CARD BASE ---- */
+.card {
+  background: linear-gradient(145deg, #f8f8f3, #f0f0eb);
+  border: 4px solid #1a1a1a;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 
+    8px 8px 0 #1a1a1a,
+    0 12px 32px rgba(0, 0, 0, 0.2);
+}
+
+.card-title h3,
+.card-header h3 {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 14px;
+  color: #cc2200;
+  margin: 0 0 8px;
+}
+
+.card-title p,
+.card-header p {
+  font-family: 'Nunito', sans-serif;
+  font-size: 13px;
+  color: #666;
+  margin: 0;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+
+/* ---- FORM FIELDS ---- */
+.field {
+  margin-top: 20px;
+}
+
+.field label {
+  display: block;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 9px;
+  color: #1a1a1a;
+  margin-bottom: 8px;
+  letter-spacing: 0.5px;
+}
+
+.field-hint {
+  font-family: 'Nunito', sans-serif;
+  font-size: 12px;
+  color: #1a5fb4;
+  margin: 4px 0 8px;
+}
+
+.field input[type="text"] {
+  width: 100%;
+  padding: 12px 14px;
+  background: #ffffff;
+  border: 3px solid #1a1a1a;
+  border-radius: 8px;
+  font-family: 'Nunito', sans-serif;
+  font-size: 14px;
+  color: #1a1a1a;
+  box-shadow: 2px 2px 0 #1a1a1a;
+  transition: all 0.2s ease;
+}
+
+.field input[type="text"]:focus {
+  outline: none;
+  border-color: #1a5fb4;
+  box-shadow: 3px 3px 0 #1a5fb4;
+}
+
+.field input[type="text"]::placeholder {
+  color: #999;
+}
+
+.search-box {
+  margin-bottom: 12px;
+}
+
+.search-box input {
+  width: 100%;
+  padding: 10px 12px;
+  background: #ffffff;
+  border: 2px solid #1a1a1a;
+  border-radius: 6px;
+  font-family: 'Nunito', sans-serif;
+  font-size: 13px;
+  box-shadow: 2px 2px 0 #1a1a1a;
+}
+
+.search-box input:focus {
+  outline: none;
+  border-color: #1a5fb4;
+}
+
+/* ---- POKEMON SELECTOR ---- */
+.pokemon-selector {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+  gap: 10px;
+  max-height: 280px;
+  overflow-y: auto;
+  padding: 8px;
+  background: rgba(0, 0, 0, 0.03);
+  border: 2px solid #e0e0e0;
+  border-radius: 8px;
+}
+
+.pokemon-selector.compact {
+  max-height: 200px;
+}
+
+.pokemon-option {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 8px;
+  background: linear-gradient(145deg, #ffffff, #f8f8f8);
+  border: 2px solid #ddd;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.pokemon-option:hover {
+  border-color: #1a5fb4;
+  transform: translateY(-2px);
+  box-shadow: 2px 2px 0 #1a5fb4;
+}
+
+.pokemon-option.selected {
+  background: linear-gradient(145deg, #e3f2fd, #bbdefb);
+  border-color: #1a5fb4;
+  box-shadow: 2px 2px 0 #1a5fb4;
+}
+
+.pokemon-option img {
+  width: 48px;
+  height: 48px;
+  object-fit: contain;
+  image-rendering: pixelated;
+}
+
+.pokemon-name {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 7px;
+  color: #1a1a1a;
+  text-align: center;
+  max-width: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ---- BUTTONS ---- */
+.actions {
+  margin-top: 20px;
+  display: flex;
+  gap: 10px;
+}
+
+.btn {
+  padding: 12px 16px;
+  border: 3px solid #1a1a1a;
+  border-radius: 8px;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 9px;
+  letter-spacing: 0.5px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  box-shadow: 3px 3px 0 #1a1a1a;
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background: linear-gradient(145deg, #cc2200, #e63900);
+  color: #fff;
+  border-color: #1a1a1a;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: linear-gradient(145deg, #e63900, #ff4500);
+  transform: translateY(-2px);
+  box-shadow: 4px 4px 0 #1a1a1a;
+}
+
+.btn-primary:active:not(:disabled) {
+  transform: translate(1px, 1px);
+  box-shadow: 2px 2px 0 #1a1a1a;
+}
+
+.btn-ghost {
+  background: linear-gradient(145deg, #ffffff, #f5f5f5);
+  color: #1a1a1a;
+}
+
+.btn-ghost:hover:not(:disabled) {
+  background: linear-gradient(145deg, #e3f2fd, #bbdefb);
+  border-color: #1a5fb4;
+}
+
+.btn-danger {
+  background: linear-gradient(145deg, #ff6b6b, #d00000);
+  color: #fff;
+}
+
+.btn-danger:hover:not(:disabled) {
+  background: linear-gradient(145deg, #ff8a8a, #e63333);
+  transform: translateY(-2px);
+  box-shadow: 4px 4px 0 #1a1a1a;
+}
+
+/* ---- ERROR MESSAGE ---- */
+.error-message {
+  margin-top: 12px;
+  padding: 10px 14px;
+  background: linear-gradient(145deg, #ffebee, #ffcdd2);
+  border: 2px solid #d32f2f;
+  border-radius: 6px;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 8px;
+  color: #c62828;
+}
+
+/* ---- LOADING / EMPTY STATES ---- */
+.loading-state,
+.empty-state {
+  padding: 32px 20px;
+  text-align: center;
+  background: linear-gradient(145deg, #ffffff, #f8f8f8);
+  border: 3px dashed #1a5fb4;
+  border-radius: 8px;
+}
+
+.loading-state p,
+.empty-state p {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 11px;
+  color: #1a1a1a;
+  margin: 8px 0 0;
+}
+
+.empty-state small {
+  font-family: 'Nunito', sans-serif;
+  font-size: 12px;
+  color: #999;
+}
+
+.empty-icon {
+  margin-bottom: 12px;
+}
+
+.empty-icon img {
+  width: 64px;
+  height: 64px;
+  image-rendering: pixelated;
+  opacity: 0.5;
+}
+
+/* ---- TEAMS GRID ---- */
+.teams-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 16px;
+}
+
+.team-card {
+  background: linear-gradient(145deg, #ffffff, #f8f8f8);
+  border: 3px solid #1a1a1a;
+  border-radius: 10px;
+  padding: 16px;
+  box-shadow: 4px 4px 0 #1a1a1a;
+  transition: all 0.2s ease;
+}
+
+.team-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 6px 6px 0 #1a1a1a;
+}
+
+.team-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+  padding-bottom: 10px;
+  border-bottom: 2px solid #e0e0e0;
+}
+
+.team-header h4 {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 11px;
+  color: #1a1a1a;
+  margin: 0;
+}
+
+.team-badge {
+  background: linear-gradient(145deg, #e3f2fd, #bbdefb);
+  border: 2px solid #1a5fb4;
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 8px;
+  color: #1a5fb4;
+}
+
+/* ---- TEAM POKEMONS ---- */
+.team-pokemons {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 6px;
+  margin-bottom: 12px;
+}
+
+.pokemon-slot {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 4px;
+  background: linear-gradient(145deg, #fff8e1, #ffecb3);
+  border: 2px solid #f9a825;
+  border-radius: 6px;
+}
+
+.pokemon-slot img {
+  width: 32px;
+  height: 32px;
+  object-fit: contain;
+  image-rendering: pixelated;
+}
+
+.slot-name {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 5px;
+  color: #1a1a1a;
+  text-align: center;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pokemon-slot.empty {
+  background: linear-gradient(145deg, #f5f5f5, #e0e0e0);
+  border-color: #bdbdbd;
+}
+
+.empty-slot {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 16px;
+  color: #bdbdbd;
+  line-height: 32px;
+}
+
+.team-info {
+  margin-bottom: 12px;
+}
+
+.info-count {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 8px;
+  color: #666;
+}
+
+/* ---- TEAM ACTIONS ---- */
+.team-actions,
+.edit-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.team-actions .btn,
+.edit-actions .btn {
+  padding: 8px 12px;
+  font-size: 8px;
+}
+
+/* ---- EDIT PANEL ---- */
+.edit-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.edit-panel .field {
+  margin-top: 0;
+}
+
+.edit-panel .field label {
+  font-size: 8px;
+  margin-bottom: 6px;
+}
+
+.edit-panel .field input {
+  padding: 10px 12px;
+}
+
+/* ---- RESPONSIVE ---- */
+@media (max-width: 1024px) {
+  .manager-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-card {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-illustration {
+    order: -1;
+  }
+
+  .hero-illustration img {
+    max-width: 150px;
+  }
+}
+
+@media (max-width: 768px) {
+  .header-content {
+    flex-direction: column;
+    gap: 12px;
+    align-items: stretch;
+  }
+
+  .header-user {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .logo-text h1 {
+    font-size: 14px;
+  }
+
+  .btn-back {
+    align-self: flex-start;
+  }
+
+  .page-main {
+    padding: 16px;
+  }
+
+  .hero-card {
+    padding: 20px;
+  }
+
+  .hero-copy h2 {
+    font-size: 14px;
+  }
+
+  .card {
+    padding: 16px;
+  }
+
+  .teams-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .team-pokemons {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .pokemon-selector {
+    grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+  }
+}
+
+/* ---- SCROLLBAR ---- */
+.pokemon-selector::-webkit-scrollbar,
+.teams-card::-webkit-scrollbar {
+  width: 8px;
+}
+
+.pokemon-selector::-webkit-scrollbar-track,
+.teams-card::-webkit-scrollbar-track {
+  background: rgba(0, 0, 0, 0.05);
+  border-radius: 4px;
+}
+
+.pokemon-selector::-webkit-scrollbar-thumb,
+.teams-card::-webkit-scrollbar-thumb {
+  background: #1a5fb4;
+  border-radius: 4px;
+}
+
+.pokemon-selector::-webkit-scrollbar-thumb:hover,
+.teams-card::-webkit-scrollbar-thumb:hover {
+  background: #0f3d7a;
+}
+
+/* ---- ANIMATIONS ---- */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.team-card {
+  animation: fadeIn 0.3s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation: none !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/frontend/src/app/features/time-manager/time-manager.component.html
+++ b/frontend/src/app/features/time-manager/time-manager.component.html
@@ -1,0 +1,211 @@
+<div class="time-page">
+  <div class="bg-sky"></div>
+
+  <header class="page-header">
+    <div class="header-content">
+      <div class="header-logo">
+        <img src="/icons/poke-ball.png" alt="Time" class="logo-img" />
+        <div class="logo-text">
+          <h1>Meus Times</h1>
+          <p>Gerencie suas equipes de batalha</p>
+        </div>
+      </div>
+
+      <div class="header-user">
+        <span class="user-name">{{ currentUser?.nome }}</span>
+        <span class="user-email">{{ currentUser?.email }}</span>
+        <button class="btn-back" (click)="goHome()">Voltar</button>
+      </div>
+    </div>
+  </header>
+
+  <div class="page-main">
+    <section class="hero-card">
+      <div class="hero-copy">
+        <h2>Monte a equipe perfeita</h2>
+        <p>
+          Crie times com ate 6 pokemons e prepare-se para os torneios.
+          Organize seus monstrinhos como nos jogos classicos!
+        </p>
+        <div class="hero-stats">
+          <div class="chip">
+            <span class="chip-label">Times</span>
+            <strong>{{ times.length }}</strong>
+          </div>
+          <div class="chip">
+            <span class="chip-label">Pokemons disponiveis</span>
+            <strong>{{ pokemons.length }}</strong>
+          </div>
+        </div>
+      </div>
+      <div class="hero-illustration">
+        <img src="/images/pokemon-header.gif" alt="Pokemon Team" />
+      </div>
+    </section>
+
+    <div class="manager-grid">
+      <!-- Form Card - Create New Team -->
+      <div class="card form-card">
+        <div class="card-title">
+          <h3>Criar novo Time</h3>
+          <p>Escolha um nome e selecione ate 6 pokemons.</p>
+        </div>
+
+        <div class="field">
+          <label for="time-nome">Nome do Time</label>
+          <input
+            id="time-nome"
+            type="text"
+            maxlength="50"
+            placeholder="Ex: Time Kanto, Equipe Fogo..."
+            [(ngModel)]="newTime.nome"
+          />
+        </div>
+
+        <div class="field">
+          <label>Selecione os Pokemons (max 6)</label>
+          <p class="field-hint">{{ newTime.pokemonIds.length }}/6 selecionados</p>
+          <div class="search-box">
+            <input
+              type="text"
+              placeholder="Buscar pokemon..."
+              [(ngModel)]="searchPokemon"
+            />
+          </div>
+          <div class="pokemon-selector" *ngIf="!loadingPokemons">
+            <div
+              class="pokemon-option"
+              *ngFor="let pokemon of availablePokemons"
+              [class.selected]="isSelected('new', pokemon.id)"
+              (click)="togglePokemonSelection('new', pokemon.id)"
+            >
+              <img [src]="sprite(pokemon)" [alt]="pokemon.apelido || pokemon.especie?.nome" />
+              <span class="pokemon-name">{{ pokemon.apelido || pokemon.especie?.nome }}</span>
+            </div>
+          </div>
+          <div class="loading-state" *ngIf="loadingPokemons">
+            <p>Carregando pokemons...</p>
+          </div>
+        </div>
+
+        <div class="actions">
+          <button
+            class="btn btn-primary"
+            (click)="criarTime()"
+            [disabled]="savingTime || !newTime.nome.trim()"
+          >
+            {{ savingTime ? 'Criando...' : 'Criar Time' }}
+          </button>
+        </div>
+
+        <p class="error-message" *ngIf="errorMessage">{{ errorMessage }}</p>
+      </div>
+
+      <!-- Teams List Card -->
+      <div class="card teams-card">
+        <div class="card-header">
+          <div>
+            <h3>Seus Times</h3>
+            <p>Edite ou remova suas equipes de batalha.</p>
+          </div>
+          <div class="search-box">
+            <input
+              type="text"
+              placeholder="Buscar time ou pokemon..."
+              [(ngModel)]="searchTime"
+            />
+          </div>
+        </div>
+
+        <div class="loading-state" *ngIf="loadingTimes">
+          <p>Carregando times...</p>
+        </div>
+
+        <div class="empty-state" *ngIf="!loadingTimes && filteredTimes.length === 0">
+          <div class="empty-icon">
+            <img src="/icons/poke-ball.png" alt="Empty" />
+          </div>
+          <p>Nenhum time encontrado</p>
+          <small>Crie seu primeiro time ao lado!</small>
+        </div>
+
+        <div class="teams-grid" *ngIf="!loadingTimes && filteredTimes.length > 0">
+          <div class="team-card" *ngFor="let time of filteredTimes">
+            <!-- View Mode -->
+            <ng-container *ngIf="editingTimeId !== time.id">
+              <div class="team-header">
+                <h4>{{ time.nome }}</h4>
+                <span class="team-badge">#{{ time.id }}</span>
+              </div>
+
+              <div class="team-pokemons">
+                <div class="pokemon-slot" *ngFor="let pokemon of time.pokemons">
+                  <img [src]="sprite(pokemon)" [alt]="pokemon.apelido || pokemon.especie?.nome" />
+                  <span class="slot-name">{{ pokemon.apelido || pokemon.especie?.nome }}</span>
+                </div>
+                <div class="pokemon-slot empty" *ngFor="let _ of getEmptySlots(time)">
+                  <span class="empty-slot">?</span>
+                </div>
+              </div>
+
+              <div class="team-info">
+                <span class="info-count">{{ time.pokemons?.length || 0 }}/6 pokemons</span>
+              </div>
+
+              <div class="team-actions">
+                <button class="btn btn-ghost" (click)="iniciarEdicao(time)">Editar</button>
+                <button
+                  class="btn btn-danger"
+                  (click)="removerTime(time)"
+                  [disabled]="deletingTimeId === time.id"
+                >
+                  {{ deletingTimeId === time.id ? 'Removendo...' : 'Remover' }}
+                </button>
+              </div>
+            </ng-container>
+
+            <!-- Edit Mode -->
+            <ng-container *ngIf="editingTimeId === time.id">
+              <div class="edit-panel">
+                <div class="field">
+                  <label>Nome do Time</label>
+                  <input
+                    type="text"
+                    [(ngModel)]="editForm.nome"
+                    maxlength="50"
+                  />
+                </div>
+
+                <div class="field">
+                  <label>Pokemons ({{ editForm.pokemonIds.length }}/6)</label>
+                  <div class="pokemon-selector compact">
+                    <div
+                      class="pokemon-option"
+                      *ngFor="let pokemon of pokemons"
+                      [class.selected]="isSelected('edit', pokemon.id)"
+                      (click)="togglePokemonSelection('edit', pokemon.id)"
+                    >
+                      <img [src]="sprite(pokemon)" [alt]="pokemon.apelido || pokemon.especie?.nome" />
+                      <span class="pokemon-name">{{ pokemon.apelido || pokemon.especie?.nome }}</span>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="edit-actions">
+                  <button class="btn btn-ghost" (click)="cancelarEdicao()">Cancelar</button>
+                  <button
+                    class="btn btn-primary"
+                    (click)="salvarEdicao()"
+                    [disabled]="savingTime"
+                  >
+                    {{ savingTime ? 'Salvando...' : 'Salvar' }}
+                  </button>
+                </div>
+              </div>
+            </ng-container>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/features/time-manager/time-manager.component.ts
+++ b/frontend/src/app/features/time-manager/time-manager.component.ts
@@ -1,0 +1,275 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { AuthService, User } from '../../core/services/auth.service';
+import { TreinadorService } from '../../core/services/treinador.service';
+import { Pokemon, Time } from '../../core/models';
+
+@Component({
+  selector: 'app-time-manager',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './time-manager.component.html',
+  styleUrls: ['./time-manager.component.css'],
+})
+export class TimeManagerComponent implements OnInit {
+  currentUser: User | null = null;
+  treinadorId?: number;
+
+  times: Time[] = [];
+  pokemons: Pokemon[] = [];
+
+  loadingTimes = true;
+  loadingPokemons = true;
+  savingTime = false;
+  deletingTimeId: number | null = null;
+  errorMessage = '';
+
+  searchTime = '';
+  searchPokemon = '';
+
+  newTime = {
+    nome: '',
+    pokemonIds: [] as number[],
+  };
+
+  editingTimeId: number | null = null;
+  editForm = {
+    nome: '',
+    pokemonIds: [] as number[],
+  };
+
+  constructor(
+    private authService: AuthService,
+    private router: Router,
+    private treinadorService: TreinadorService,
+  ) {}
+
+  ngOnInit(): void {
+    this.currentUser = this.authService.currentUser();
+    if (!this.currentUser) {
+        this.router.navigate(['/login']);
+        return;
+    }
+
+    this.treinadorId = this.currentUser.id;
+    this.loadPokemons();
+    this.loadTimes();
+  }
+
+  get filteredTimes(): Time[] {
+    const term = this.searchTime.trim().toLowerCase();
+    if (!term) return this.times;
+
+    return this.times.filter((time) =>
+      time.nome.toLowerCase().includes(term) ||
+      (time.pokemons || []).some((p) =>
+        (p.apelido || p.especie?.nome || '').toLowerCase().includes(term),
+      ),
+    );
+  }
+
+  get availablePokemons(): Pokemon[] {
+    const term = this.searchPokemon.trim().toLowerCase();
+    if (!term) return this.pokemons;
+    return this.pokemons.filter((p) =>
+      (p.apelido || '').toLowerCase().includes(term) ||
+      (p.especie?.nome || '').toLowerCase().includes(term),
+    );
+  }
+
+  loadPokemons(): void {
+    if (!this.treinadorId) return;
+    this.loadingPokemons = true;
+    this.treinadorService
+      .listarPokemonsDoTreinador(this.treinadorId)
+      .subscribe({
+        next: (lista) => {
+          this.pokemons = lista;
+          this.loadingPokemons = false;
+        },
+        error: () => {
+          this.loadingPokemons = false;
+          this.errorMessage = 'Não foi possível carregar seus pokémons.';
+        },
+      });
+  }
+
+  loadTimes(): void {
+    if (!this.treinadorId) return;
+    this.loadingTimes = true;
+    this.errorMessage = '';
+
+    this.treinadorService
+      .listarTimesDoTreinador(this.treinadorId)
+      .subscribe({
+        next: (lista) => {
+          this.times = lista;
+          this.loadingTimes = false;
+        },
+        error: () => {
+          this.loadingTimes = false;
+          this.errorMessage = 'Não conseguimos carregar seus times agora.';
+        },
+      });
+  }
+
+  togglePokemonSelection(target: 'new' | 'edit', pokemonId: number): void {
+    const list = target === 'new' ? this.newTime.pokemonIds : this.editForm.pokemonIds;
+
+    const alreadySelected = list.includes(pokemonId);
+    if (alreadySelected) {
+      const updated = list.filter((id) => id !== pokemonId);
+      if (target === 'new') this.newTime.pokemonIds = updated;
+      else this.editForm.pokemonIds = updated;
+      return;
+    }
+
+    if (list.length >= 6) {
+      this.errorMessage = 'Um time pode ter no máximo 6 pokémons.';
+      return;
+    }
+
+    const updated = [...list, pokemonId];
+    if (target === 'new') this.newTime.pokemonIds = updated;
+    else this.editForm.pokemonIds = updated;
+  }
+
+  isSelected(target: 'new' | 'edit', pokemonId: number): boolean {
+    const list = target === 'new' ? this.newTime.pokemonIds : this.editForm.pokemonIds;
+    return list.includes(pokemonId);
+  }
+
+  criarTime(): void {
+    if (!this.treinadorId || this.savingTime) return;
+    this.errorMessage = '';
+
+    const nome = this.newTime.nome.trim();
+    if (!nome) {
+      this.errorMessage = 'O nome do time é obrigatório.';
+      return;
+    }
+
+    this.savingTime = true;
+
+    this.treinadorService
+      .criarTimeParaTreinador(this.treinadorId, {
+        nome,
+        pokemonIds: this.newTime.pokemonIds,
+      })
+      .subscribe({
+        next: (time) => {
+          this.times = [time, ...this.times];
+          this.newTime = { nome: '', pokemonIds: [] };
+          this.savingTime = false;
+        },
+        error: (err) => {
+          this.savingTime = false;
+          this.errorMessage = this.extractErrorMessage(
+            err,
+            'Não foi possível criar o time agora.',
+          );
+        },
+      });
+  }
+
+  iniciarEdicao(time: Time): void {
+    this.editingTimeId = time.id;
+    this.editForm = {
+      nome: time.nome,
+      pokemonIds: (time.pokemons || []).map((p) => p.id),
+    };
+  }
+
+  cancelarEdicao(): void {
+    this.editingTimeId = null;
+    this.editForm = { nome: '', pokemonIds: [] };
+  }
+
+  salvarEdicao(): void {
+    if (!this.treinadorId || this.editingTimeId === null) return;
+    const nome = this.editForm.nome.trim();
+    if (!nome) {
+      this.errorMessage = 'O nome do time é obrigatório.';
+      return;
+    }
+
+    if (this.editForm.pokemonIds.length > 6) {
+      this.errorMessage = 'Um time pode ter no máximo 6 pokémons.';
+      return;
+    }
+
+    this.savingTime = true;
+    this.treinadorService
+      .atualizarTimeDoTreinador(this.treinadorId, this.editingTimeId, {
+        nome,
+        pokemonIds: this.editForm.pokemonIds,
+      })
+      .subscribe({
+        next: (timeAtualizado) => {
+          this.times = this.times.map((t) =>
+            t.id === timeAtualizado.id ? timeAtualizado : t,
+          );
+          this.savingTime = false;
+          this.cancelarEdicao();
+        },
+        error: (err) => {
+          this.savingTime = false;
+          this.errorMessage = this.extractErrorMessage(
+            err,
+            'Não foi possível atualizar o time.',
+          );
+        },
+      });
+  }
+
+  removerTime(time: Time): void {
+    if (!this.treinadorId || this.deletingTimeId) return;
+
+    const confirmDelete = confirm(`Liberar o time "${time.nome}"?`);
+    if (!confirmDelete) return;
+
+    this.deletingTimeId = time.id;
+    this.treinadorService
+      .deletarTimeDoTreinador(this.treinadorId, time.id)
+      .subscribe({
+        next: () => {
+          this.times = this.times.filter((t) => t.id !== time.id);
+          this.deletingTimeId = null;
+        },
+        error: (err) => {
+          this.errorMessage = this.extractErrorMessage(
+            err,
+            'Não foi possível remover o time agora.',
+          );
+          this.deletingTimeId = null;
+        },
+      });
+  }
+
+  private extractErrorMessage(err: any, fallback: string): string {
+    return (
+      err?.error?.message ||
+      err?.error?.detail ||
+      err?.error?.error ||
+      fallback
+    );
+  }
+
+  sprite(pokemon: Pokemon): string {
+    return (
+      pokemon.especie?.imagemUrl || '/images/pokemon-placeholder.png'
+    );
+  }
+
+  getEmptySlots(time: Time): number[] {
+    const pokemonCount = time.pokemons?.length || 0;
+    const emptyCount = Math.max(0, 6 - pokemonCount);
+    return new Array(emptyCount);
+  }
+
+  goHome(): void {
+    this.router.navigate(['/home']);
+  }
+}


### PR DESCRIPTION
## Resumo
- adiciona CRUD aninhado de pokémons e times por treinador (`/api/treinadores/{treinadorId}/...`) e cria DTOs de request para payloads enxutos
- implementa gerenciamento de ataques do pokémon (listar, definir lista, adicionar e remover) com validação de até 4 ataques
- cria telas de gerenciamento em Angular para pokémons e times, incluindo modal de edição focado no pokémon (espécie, apelido e ataques)
- melhora mensagens de erro de remoção com regras de negócio (impede remover pokémon em time e time inscrito em torneio)

## Validação
- backend: `./gradlew compileJava`
- frontend: `npx ng build`