### PR TITLE
fix(delete): retornar mensagens de vínculo em exclusões

### DIFF
--- a/backend/src/main/java/com/ufape/projetobanquinhobd/auth/SecurityConfig.java
+++ b/backend/src/main/java/com/ufape/projetobanquinhobd/auth/SecurityConfig.java
@@ -3,7 +3,6 @@ package com.ufape.projetobanquinhobd.auth;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
@@ -19,6 +18,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import jakarta.servlet.DispatcherType;
 
 import java.util.List;
 
@@ -42,8 +42,10 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
                 .authorizeHttpRequests(auth -> auth
+                        .dispatcherTypeMatchers(DispatcherType.ERROR).permitAll()
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/api/estatisticas/**").permitAll()
+                        .requestMatchers("/error").permitAll()
                         .anyRequest().authenticated()
                 )
 

--- a/backend/src/main/java/com/ufape/projetobanquinhobd/services/PokemonService.java
+++ b/backend/src/main/java/com/ufape/projetobanquinhobd/services/PokemonService.java
@@ -97,7 +97,9 @@ public class PokemonService {
     }
 
     public void deletarPorId(Long id) {
-        pokemonRepository.deleteById(id);
+        Pokemon pokemon = buscarPokemonPorId(id);
+        validarPokemonNaoEstaEmTime(pokemon.getId());
+        pokemonRepository.delete(pokemon);
     }
 
     public void removerParaTreinador(Long treinadorId, Long pokemonId) {
@@ -105,15 +107,27 @@ public class PokemonService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
                         "Pokémon não encontrado para este treinador"));
 
-        if (timeRepository.existsByPokemons_Id(pokemonId)) {
-            throw new ResponseStatusException(
-                    HttpStatus.CONFLICT,
-                    "Não é possível remover este pokémon porque ele está em um time. " +
-                            "Remova o pokémon do time primeiro."
-            );
-        }
+        validarPokemonNaoEstaEmTime(pokemonId);
 
         pokemonRepository.delete(pokemon);
+    }
+
+    private void validarPokemonNaoEstaEmTime(Long pokemonId) {
+        if (!timeRepository.existsByPokemons_Id(pokemonId)) {
+            return;
+        }
+
+        throw new ResponseStatusException(
+                HttpStatus.CONFLICT,
+                "Não é possível remover este pokémon porque ele está em um time. " +
+                        "Remova o pokémon do time primeiro."
+        );
+    }
+
+    private Pokemon buscarPokemonPorId(Long pokemonId) {
+        return pokemonRepository.findById(pokemonId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Pokémon não encontrado: " + pokemonId));
     }
 
     public Set<Ataque> listarAtaquesDoPokemon(Long treinadorId, Long pokemonId) {

--- a/backend/src/main/java/com/ufape/projetobanquinhobd/services/TimeService.java
+++ b/backend/src/main/java/com/ufape/projetobanquinhobd/services/TimeService.java
@@ -87,7 +87,9 @@ public class TimeService {
     }
 
     public void deletarPorId(Long id) {
-        timeRepository.deleteById(id);
+        Time time = buscarTimePorId(id);
+        validarTimeNaoInscritoEmTorneio(time.getId());
+        timeRepository.delete(time);
     }
 
     public void removerParaTreinador(Long treinadorId, Long timeId) {
@@ -95,15 +97,27 @@ public class TimeService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
                         "Time não encontrado para este treinador"));
 
-        if (torneioRepository.existsByTimes_Id(timeId)) {
-            throw new ResponseStatusException(
-                    HttpStatus.CONFLICT,
-                    "Não é possível remover este time porque ele está inscrito em um torneio. " +
-                            "Remova o time do torneio primeiro."
-            );
-        }
+        validarTimeNaoInscritoEmTorneio(timeId);
 
         timeRepository.delete(time);
+    }
+
+    private void validarTimeNaoInscritoEmTorneio(Long timeId) {
+        if (!torneioRepository.existsByTimes_Id(timeId)) {
+            return;
+        }
+
+        throw new ResponseStatusException(
+                HttpStatus.CONFLICT,
+                "Não é possível remover este time porque ele está inscrito em um torneio. " +
+                        "Remova o time do torneio primeiro."
+        );
+    }
+
+    private Time buscarTimePorId(Long timeId) {
+        return timeRepository.findById(timeId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Time não encontrado: " + timeId));
     }
 
     private void validarTreinadorExiste(Long treinadorId) {

--- a/frontend/src/app/features/pokemon-manager/pokemon-manager.component.ts
+++ b/frontend/src/app/features/pokemon-manager/pokemon-manager.component.ts
@@ -251,6 +251,7 @@ export class PokemonManagerComponent implements OnInit {
           this.errorMessage = this.extractErrorMessage(
             err,
             'Nao foi possivel remover o pokemon.',
+            'Nao e possivel remover este pokemon porque ele esta em um time.',
           );
         },
       });
@@ -278,13 +279,23 @@ export class PokemonManagerComponent implements OnInit {
     this.editForm.ataquesNomes = [...this.editForm.ataquesNomes, ataqueNome];
   }
 
-  private extractErrorMessage(err: any, fallback: string): string {
-    return (
-      err?.error?.message ||
-      err?.error?.detail ||
-      err?.error?.error ||
-      fallback
-    );
+  private extractErrorMessage(
+    err: any,
+    fallback: string,
+    conflictFallback?: string,
+  ): string {
+    const backendMessage =
+      err?.error?.message || err?.error?.detail || err?.error?.error;
+
+    if (backendMessage) {
+      return backendMessage;
+    }
+
+    if (err?.status === 409 && conflictFallback) {
+      return conflictFallback;
+    }
+
+    return fallback;
   }
 
   imageFor(pokemon: Pokemon): string {

--- a/frontend/src/app/features/time-manager/time-manager.component.ts
+++ b/frontend/src/app/features/time-manager/time-manager.component.ts
@@ -242,19 +242,30 @@ export class TimeManagerComponent implements OnInit {
           this.errorMessage = this.extractErrorMessage(
             err,
             'Não foi possível remover o time agora.',
+            'Não é possível remover este time porque ele está em um torneio.',
           );
           this.deletingTimeId = null;
         },
       });
   }
 
-  private extractErrorMessage(err: any, fallback: string): string {
-    return (
-      err?.error?.message ||
-      err?.error?.detail ||
-      err?.error?.error ||
-      fallback
-    );
+  private extractErrorMessage(
+    err: any,
+    fallback: string,
+    conflictFallback?: string,
+  ): string {
+    const backendMessage =
+      err?.error?.message || err?.error?.detail || err?.error?.error;
+
+    if (backendMessage) {
+      return backendMessage;
+    }
+
+    if (err?.status === 409 && conflictFallback) {
+      return conflictFallback;
+    }
+
+    return fallback;
   }
 
   sprite(pokemon: Pokemon): string {


### PR DESCRIPTION
## Summary
- corrige o fluxo de exclusão para retornar erro de domínio (409) ao tentar remover pokémon que está em time e time que está em torneio
- ajusta a segurança para permitir o dispatch de erro (`/error`) e evitar mascaramento indevido para 403
- garante no frontend a exibição das mensagens do backend com fallback específico para conflitos de exclusão

## Validation
- `DELETE /api/treinadores/2/pokemons/1` retorna `409` com mensagem de vínculo em time
- `DELETE /api/treinadores/2/times/1` retorna `409` com mensagem de vínculo em torneio
- erros de recurso inexistente voltam como `404` (não mais `403` mascarado)