### PR TITLE
fix: corrige overflow dos botões nos cards de torneio

### DIFF
--- a/frontend/src/app/features/home/home.component.css
+++ b/frontend/src/app/features/home/home.component.css
@@ -770,12 +770,23 @@ html {
 
 .tournament-actions {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   margin-top: 8px;
 }
 
+.tournament-actions .btn-tournament,
+.tournament-actions select.btn-tournament {
+  flex: 1 1 calc(50% - 4px);
+  min-width: 0;
+}
+
+.tournament-actions .btn-details {
+  flex-basis: 100%;
+}
+
 .btn-tournament {
-  flex: 1;
+  flex: 1 1 calc(50% - 4px);
   padding: 10px 16px;
   border: 2px solid #1a1a1a;
   border-radius: 8px;

--- a/frontend/src/app/features/home/home.component.html
+++ b/frontend/src/app/features/home/home.component.html
@@ -250,7 +250,7 @@
                         }}
                       </button>
                       <button
-                        class="btn-tournament btn-secondary"
+                        class="btn-tournament btn-secondary btn-details"
                         (click)="verDetalhesTorneio(torneio)"
                       >
                         Ver Detalhes


### PR DESCRIPTION
## Resumo
- Corrige o overflow dos controles de ação nos cards da aba de torneios.
- Ajusta o layout de `.tournament-actions` para quebrar linha quando houver 3 ações.
- Faz o botão **Ver Detalhes** ocupar linha inteira para manter o card íntegro em diferentes larguras.

## Como validar
- Abrir a aba **Torneios** na Home.
- Verificar cards de torneios abertos com `select + Inscrever-se + Ver Detalhes`.
- Confirmar que nenhum botão ultrapassa a borda do card em desktop e resoluções menores.