### PR TITLE
feat: relatório corrido de estatísticas por view no frontend

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -62,6 +62,14 @@ export const routes: Routes = [
     canActivate: [authGuard],
   },
   {
+    path: 'relatorios',
+    loadComponent: () =>
+      import('./features/reports/reports.component').then(
+        (m) => m.ReportsComponent,
+      ),
+    canActivate: [authGuard],
+  },
+  {
     path: 'dashboard',
     redirectTo: 'home',
     pathMatch: 'full',

--- a/frontend/src/app/features/home/home.component.html
+++ b/frontend/src/app/features/home/home.component.html
@@ -58,6 +58,18 @@
             <span class="nav-label">Meu Perfil</span>
           </button>
         </li>
+        <li>
+          <button class="nav-item" (click)="goToReports()">
+            <span class="nav-icon">
+              <img
+                src="/icons/combo-chart.png"
+                alt="Relatórios"
+                class="nav-icon-img"
+              />
+            </span>
+            <span class="nav-label">Relatórios</span>
+          </button>
+        </li>
         <li *ngIf="isAdmin">
           <button
             class="nav-item"

--- a/frontend/src/app/features/home/home.component.ts
+++ b/frontend/src/app/features/home/home.component.ts
@@ -587,6 +587,10 @@ export class HomeComponent implements OnInit {
     this.router.navigate(['/times']);
   }
 
+  goToReports(): void {
+    this.router.navigate(['/relatorios']);
+  }
+
   // ─── Torneio Actions ─────────────────────────────────────────────────────────
 
   inscreverNoTorneio(torneio: Torneio): void {

--- a/frontend/src/app/features/reports/reports.component.css
+++ b/frontend/src/app/features/reports/reports.component.css
@@ -1,0 +1,190 @@
+* {
+  box-sizing: border-box;
+}
+
+.reports-page {
+  min-height: 100vh;
+  padding: 24px;
+  position: relative;
+  font-family: 'Nunito', 'Segoe UI', sans-serif;
+}
+
+.reports-bg {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  background:
+    linear-gradient(180deg, rgba(0, 0, 0, 0.12), rgba(0, 0, 0, 0.18)),
+    url('/images/city-pk.png') center / cover no-repeat;
+}
+
+.reports-header {
+  max-width: 1320px;
+  margin: 0 auto 20px;
+  background: linear-gradient(145deg, #f8f8f3, #f0f0eb);
+  border: 4px solid #1a1a1a;
+  border-radius: 12px;
+  padding: 18px 20px;
+  box-shadow:
+    8px 8px 0 #1a1a1a,
+    0 12px 24px rgba(0, 0, 0, 0.25);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.reports-header h1 {
+  margin: 0;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 20px;
+  color: #cc2200;
+}
+
+.reports-header p {
+  margin: 8px 0 0;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 9px;
+  color: #666;
+}
+
+.btn-back {
+  border: 3px solid #1a1a1a;
+  border-radius: 10px;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 9px;
+  padding: 12px 14px;
+  cursor: pointer;
+  background: linear-gradient(145deg, #ffde59, #ffb347);
+}
+
+.reports-content {
+  max-width: 1320px;
+  margin: 0 auto;
+}
+
+.panel {
+  background: linear-gradient(145deg, #f8f8f3, #f0f0eb);
+  border: 4px solid #1a1a1a;
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow:
+    10px 10px 0 #1a1a1a,
+    0 14px 30px rgba(0, 0, 0, 0.25);
+}
+
+.table-section {
+  margin-bottom: 24px;
+}
+
+.table-section:last-child {
+  margin-bottom: 0;
+}
+
+.table-section h2 {
+  margin: 0 0 12px;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 12px;
+  color: #1a1a1a;
+  line-height: 1.4;
+}
+
+.filter-label {
+  font-size: 12px;
+  font-weight: 700;
+  display: block;
+  margin-bottom: 8px;
+}
+
+.filter-select {
+  width: 100%;
+  max-width: 560px;
+  border: 3px solid #1a1a1a;
+  border-radius: 8px;
+  background: #fff;
+  padding: 10px 12px;
+  margin-bottom: 16px;
+  font-size: 14px;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  border: 3px solid #1a1a1a;
+  border-radius: 10px;
+  background: #fff;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 700px;
+}
+
+thead th {
+  background: #1a5fb4;
+  color: #fff;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 8px;
+  letter-spacing: 0.5px;
+  text-align: left;
+  padding: 12px;
+}
+
+tbody td {
+  border-top: 1px solid #d8d8d8;
+  padding: 12px;
+  font-size: 13px;
+  color: #1f1f1f;
+}
+
+tbody tr:nth-child(even) {
+  background: #f7f7f7;
+}
+
+.empty {
+  text-align: center;
+  color: #666;
+  font-style: italic;
+}
+
+.state {
+  padding: 12px;
+  border: 2px dashed #aaa;
+  border-radius: 10px;
+  font-size: 14px;
+  margin-bottom: 10px;
+}
+
+.state.error {
+  border-color: #cc2200;
+  color: #cc2200;
+}
+
+.pokemon-thumb {
+  width: 42px;
+  height: 42px;
+  object-fit: contain;
+}
+
+@media (max-width: 780px) {
+  .reports-page {
+    padding: 14px;
+  }
+
+  .reports-header h1 {
+    font-size: 14px;
+  }
+
+  .reports-header p {
+    font-size: 8px;
+  }
+
+  .panel {
+    padding: 14px;
+  }
+
+  table {
+    min-width: 620px;
+  }
+}

--- a/frontend/src/app/features/reports/reports.component.html
+++ b/frontend/src/app/features/reports/reports.component.html
@@ -1,0 +1,166 @@
+<div class="reports-page">
+  <div class="reports-bg"></div>
+
+  <header class="reports-header">
+    <div>
+      <h1>Relatórios</h1>
+      <p>Consulta das views de estatísticas do sistema</p>
+    </div>
+    <button class="btn-back" (click)="voltarHome()">Voltar para Home</button>
+  </header>
+
+  <main class="reports-content">
+    <section class="panel">
+      <div class="table-section">
+        <h2>Desempenho do treinador no torneio (v_treinador_desempenho_torneio)</h2>
+
+        <label class="filter-label" for="torneioSelectDesempenho">Selecione o torneio</label>
+        <select
+          id="torneioSelectDesempenho"
+          class="filter-select"
+          [value]="torneioDesempenhoSelecionadoId ?? ''"
+          (change)="onTorneioDesempenhoSelecionado($event)"
+        >
+          <option value="" disabled *ngIf="torneios.length === 0">Nenhum torneio disponível</option>
+          <option *ngFor="let torneio of torneios" [value]="torneio.id">
+            {{ torneio.nome }}
+          </option>
+        </select>
+
+        <div *ngIf="loadingDesempenho" class="state">Carregando desempenho...</div>
+        <div *ngIf="!loadingDesempenho && errorDesempenho" class="state error">{{ errorDesempenho }}</div>
+
+        <div class="table-wrapper" *ngIf="!loadingDesempenho">
+          <table>
+            <thead>
+              <tr>
+                <th>Treinador</th>
+                <th>Time</th>
+                <th>Batalhas</th>
+                <th>Vitórias</th>
+                <th>Derrotas</th>
+                <th>% Vitórias</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngFor="let item of desempenhoTorneio">
+                <td>{{ item.treinadorNome }}</td>
+                <td>{{ item.timeNome }}</td>
+                <td>{{ item.totalBatalhas }}</td>
+                <td>{{ item.totalVitorias }}</td>
+                <td>{{ item.totalDerrotas }}</td>
+                <td>{{ formatPercent(item.percentualVitorias) }}</td>
+              </tr>
+              <tr *ngIf="desempenhoTorneio.length === 0">
+                <td colspan="6" class="empty">Sem dados para o torneio selecionado.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="table-section">
+        <h2>Resumo das batalhas do torneio (v_resumo_batalhas_torneio)</h2>
+
+        <label class="filter-label" for="torneioSelectResumo">Selecione o torneio</label>
+        <select
+          id="torneioSelectResumo"
+          class="filter-select"
+          [value]="torneioResumoSelecionadoId ?? ''"
+          (change)="onTorneioResumoSelecionado($event)"
+        >
+          <option value="" disabled *ngIf="torneios.length === 0">Nenhum torneio disponível</option>
+          <option *ngFor="let torneio of torneios" [value]="torneio.id">
+            {{ torneio.nome }}
+          </option>
+        </select>
+
+        <div *ngIf="loadingResumoBatalhas" class="state">Carregando resumo de batalhas...</div>
+        <div *ngIf="!loadingResumoBatalhas && errorResumoBatalhas" class="state error">{{ errorResumoBatalhas }}</div>
+
+        <div class="table-wrapper" *ngIf="!loadingResumoBatalhas">
+          <table>
+            <thead>
+              <tr>
+                <th>Batalha</th>
+                <th>Rodada</th>
+                <th>Início</th>
+                <th>Fim</th>
+                <th>Duração</th>
+                <th>Vencedor</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngFor="let item of resumoBatalhasTorneio">
+                <td>#{{ item.batalhaId }}</td>
+                <td>{{ item.rodada }}</td>
+                <td>{{ formatDateTime(item.horarioInicio) }}</td>
+                <td>{{ formatDateTime(item.horarioFim) }}</td>
+                <td>{{ formatDuration(item.duracaoMinutos) }}</td>
+                <td>{{ item.timeVencedorNome || '-' }}</td>
+              </tr>
+              <tr *ngIf="resumoBatalhasTorneio.length === 0">
+                <td colspan="6" class="empty">Sem batalhas para o torneio selecionado.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="table-section">
+        <h2>Pokémons detalhados do time (v_time_pokemons_detalhado)</h2>
+
+        <label class="filter-label" for="timeSelect">Selecione o time</label>
+        <select
+          id="timeSelect"
+          class="filter-select"
+          [value]="timeSelecionadoId ?? ''"
+          (change)="onTimeSelecionado($event)"
+        >
+          <option value="" disabled *ngIf="times.length === 0">Nenhum time disponível</option>
+          <option *ngFor="let time of times" [value]="time.id">
+            {{ time.nome }} ({{ time.treinador ? time.treinador.nome : 'Sem treinador' }})
+          </option>
+        </select>
+
+        <div *ngIf="loadingPokemonsTime" class="state">Carregando pokémons do time...</div>
+        <div *ngIf="!loadingPokemonsTime && errorPokemonsTime" class="state error">{{ errorPokemonsTime }}</div>
+
+        <div class="table-wrapper" *ngIf="!loadingPokemonsTime">
+          <table>
+            <thead>
+              <tr>
+                <th>Treinador</th>
+                <th>Time</th>
+                <th>Pokémon</th>
+                <th>Espécie</th>
+                <th>Tipos</th>
+                <th>Imagem</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngFor="let item of pokemonsDoTime">
+                <td>{{ item.treinadorNome }}</td>
+                <td>{{ item.timeNome }}</td>
+                <td>{{ item.pokemonApelido || '-' }}</td>
+                <td>{{ item.especieNome }}</td>
+                <td>{{ item.tipos }}</td>
+                <td>
+                  <img
+                    *ngIf="item.especieImagemUrl"
+                    [src]="item.especieImagemUrl"
+                    [alt]="item.especieNome"
+                    class="pokemon-thumb"
+                  />
+                </td>
+              </tr>
+              <tr *ngIf="pokemonsDoTime.length === 0">
+                <td colspan="6" class="empty">Sem pokémons para o time selecionado.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  </main>
+</div>

--- a/frontend/src/app/features/reports/reports.component.ts
+++ b/frontend/src/app/features/reports/reports.component.ts
@@ -1,0 +1,209 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+import { EstatisticasService } from '../../core/services/estatisticas.service';
+import { TreinadorService } from '../../core/services/treinador.service';
+import { TorneioService } from '../../core/services/torneio.service';
+import {
+  ResumoBatalhaTorneio,
+  Time,
+  TimePokemonDetalhado,
+  Torneio,
+  TreinadorDesempenho,
+} from '../../core/models';
+
+@Component({
+  selector: 'app-reports',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './reports.component.html',
+  styleUrl: './reports.component.css',
+})
+export class ReportsComponent implements OnInit {
+  loadingDesempenho = false;
+  loadingResumoBatalhas = false;
+  loadingPokemonsTime = false;
+
+  errorDesempenho = '';
+  errorResumoBatalhas = '';
+  errorPokemonsTime = '';
+
+  torneios: Torneio[] = [];
+  times: Time[] = [];
+
+  torneioDesempenhoSelecionadoId: number | null = null;
+  torneioResumoSelecionadoId: number | null = null;
+  timeSelecionadoId: number | null = null;
+
+  desempenhoTorneio: TreinadorDesempenho[] = [];
+  resumoBatalhasTorneio: ResumoBatalhaTorneio[] = [];
+  pokemonsDoTime: TimePokemonDetalhado[] = [];
+
+  constructor(
+    private estatisticasService: EstatisticasService,
+    private torneioService: TorneioService,
+    private treinadorService: TreinadorService,
+    private router: Router,
+  ) {}
+
+  ngOnInit(): void {
+    this.carregarEntidadesBase();
+  }
+
+  voltarHome(): void {
+    this.router.navigate(['/home']);
+  }
+
+  carregarEntidadesBase(): void {
+    this.torneioService.listarTorneios().subscribe({
+      next: (data) => {
+        this.torneios = data;
+
+        if (this.torneios.length > 0) {
+          this.torneioDesempenhoSelecionadoId =
+            this.torneioDesempenhoSelecionadoId ?? this.torneios[0].id;
+          this.torneioResumoSelecionadoId =
+            this.torneioResumoSelecionadoId ?? this.torneios[0].id;
+          this.carregarDesempenhoTorneio();
+          this.carregarResumoBatalhasTorneio();
+        }
+      },
+      error: () => {
+        this.torneios = [];
+      },
+    });
+
+    this.treinadorService.listarTimes().subscribe({
+      next: (data) => {
+        this.times = data;
+
+        if (this.times.length > 0) {
+          this.timeSelecionadoId = this.timeSelecionadoId ?? this.times[0].id;
+          this.carregarPokemonsDoTime();
+        }
+      },
+      error: () => {
+        this.times = [];
+      },
+    });
+  }
+
+  onTorneioDesempenhoSelecionado(event: Event): void {
+    const value = (event.target as HTMLSelectElement).value;
+    this.torneioDesempenhoSelecionadoId = value ? Number(value) : null;
+    this.carregarDesempenhoTorneio();
+  }
+
+  onTorneioResumoSelecionado(event: Event): void {
+    const value = (event.target as HTMLSelectElement).value;
+    this.torneioResumoSelecionadoId = value ? Number(value) : null;
+    this.carregarResumoBatalhasTorneio();
+  }
+
+  onTimeSelecionado(event: Event): void {
+    const value = (event.target as HTMLSelectElement).value;
+    this.timeSelecionadoId = value ? Number(value) : null;
+    this.carregarPokemonsDoTime();
+  }
+
+  carregarDesempenhoTorneio(): void {
+    if (!this.torneioDesempenhoSelecionadoId) {
+      this.desempenhoTorneio = [];
+      return;
+    }
+
+    this.loadingDesempenho = true;
+    this.errorDesempenho = '';
+
+    this.estatisticasService
+      .obterDesempenhoTreinadores(this.torneioDesempenhoSelecionadoId)
+      .subscribe({
+        next: (data) => {
+          this.desempenhoTorneio = data;
+          this.loadingDesempenho = false;
+        },
+        error: () => {
+          this.desempenhoTorneio = [];
+          this.errorDesempenho =
+            'Não foi possível carregar o desempenho dos treinadores.';
+          this.loadingDesempenho = false;
+        },
+      });
+  }
+
+  carregarResumoBatalhasTorneio(): void {
+    if (!this.torneioResumoSelecionadoId) {
+      this.resumoBatalhasTorneio = [];
+      return;
+    }
+
+    this.loadingResumoBatalhas = true;
+    this.errorResumoBatalhas = '';
+
+    this.estatisticasService
+      .obterResumoBatalhasTorneio(this.torneioResumoSelecionadoId)
+      .subscribe({
+        next: (data) => {
+          this.resumoBatalhasTorneio = data;
+          this.loadingResumoBatalhas = false;
+        },
+        error: () => {
+          this.resumoBatalhasTorneio = [];
+          this.errorResumoBatalhas =
+            'Não foi possível carregar o resumo das batalhas do torneio.';
+          this.loadingResumoBatalhas = false;
+        },
+      });
+  }
+
+  carregarPokemonsDoTime(): void {
+    if (!this.timeSelecionadoId) {
+      this.pokemonsDoTime = [];
+      return;
+    }
+
+    this.loadingPokemonsTime = true;
+    this.errorPokemonsTime = '';
+
+    this.estatisticasService.obterPokemonsDoTime(this.timeSelecionadoId).subscribe({
+      next: (data) => {
+        this.pokemonsDoTime = data;
+        this.loadingPokemonsTime = false;
+      },
+      error: () => {
+        this.pokemonsDoTime = [];
+        this.errorPokemonsTime =
+          'Não foi possível carregar os pokémons detalhados do time.';
+        this.loadingPokemonsTime = false;
+      },
+    });
+  }
+
+  formatDateTime(dateString: string | null | undefined): string {
+    if (!dateString) return '-';
+
+    const date = new Date(dateString);
+    if (Number.isNaN(date.getTime())) return '-';
+
+    return date.toLocaleString('pt-BR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  }
+
+  formatPercent(value: number | null | undefined): string {
+    if (value === null || value === undefined || Number.isNaN(value)) return '0%';
+    return `${value.toFixed(2)}%`;
+  }
+
+  formatDuration(minutes: number | null | undefined): string {
+    if (minutes === null || minutes === undefined || Number.isNaN(minutes)) {
+      return '-';
+    }
+
+    return `${minutes.toFixed(1)} min`;
+  }
+}


### PR DESCRIPTION
## O que foi feito
- criada a rota protegida de relatórios no frontend
- adicionada navegação para Relatórios na Home
- implementada página de relatórios em formato corrido (sem abas), com três blocos em sequência:
  - Desempenho do treinador no torneio (v_treinador_desempenho_torneio)
  - Resumo das batalhas do torneio (v_resumo_batalhas_torneio)
  - Pokémons detalhados do time (v_time_pokemons_detalhado)

## Validação
- build do frontend executado com sucesso ()

<img width="361" height="404" alt="image" src="https://github.com/user-attachments/assets/cdd16c71-e8cb-4501-914b-ef4c25a48d16" />
