### PR TITLE
Corrige cards de estatísticas do perfil (títulos por torneio)

### DIFF
--- a/backend/src/main/java/com/ufape/projetobanquinhobd/controllers/EstatisticasController.java
+++ b/backend/src/main/java/com/ufape/projetobanquinhobd/controllers/EstatisticasController.java
@@ -151,6 +151,27 @@ public class EstatisticasController {
         return ResponseEntity.ok(desempenho);
     }
 
+    // GET /api/estatisticas/treinador/{treinadorId}/titulos
+    // Retorna quantos torneios encerrados o treinador venceu (campeão da final)
+    @GetMapping("/treinador/{treinadorId}/titulos")
+    public ResponseEntity<Map<String, Object>> obterTitulosTreinador(@PathVariable Long treinadorId) {
+        Long totalTitulos = jdbcTemplate.queryForObject(
+            "SELECT COUNT(DISTINCT t.id) " +
+            "FROM torneio t " +
+            "JOIN batalha b ON b.torneio_id = t.id " +
+            "JOIN time tm ON tm.id = b.time_vencedor_id " +
+            "WHERE tm.treinador_id = ? " +
+            "  AND t.status = 'ENCERRADO' " +
+            "  AND b.rodada = (SELECT MAX(b2.rodada) FROM batalha b2 WHERE b2.torneio_id = t.id)",
+            Long.class,
+            treinadorId
+        );
+
+        Map<String, Object> response = new java.util.LinkedHashMap<>();
+        response.put("totalTitulos", totalTitulos != null ? totalTitulos : 0);
+        return ResponseEntity.ok(response);
+    }
+
     // GET /api/estatisticas/torneio/{torneioId}/resumo-batalhas
     // Consulta a view v_resumo_batalhas_torneio
     @GetMapping("/torneio/{torneioId}/resumo-batalhas")

--- a/frontend/src/app/core/services/estatisticas.service.ts
+++ b/frontend/src/app/core/services/estatisticas.service.ts
@@ -51,6 +51,12 @@ export class EstatisticasService {
     );
   }
 
+  obterTitulosTreinador(treinadorId: number): Observable<{ totalTitulos: number }> {
+    return this.http.get<{ totalTitulos: number }>(
+      `${this.apiUrl}/treinador/${treinadorId}/titulos`
+    );
+  }
+
   obterResumoBatalhasTorneio(torneioId: number): Observable<ResumoBatalhaTorneio[]> {
     return this.http.get<ResumoBatalhaTorneio[]>(
       `${this.apiUrl}/torneio/${torneioId}/resumo-batalhas`

--- a/frontend/src/app/features/home/home.component.html
+++ b/frontend/src/app/features/home/home.component.html
@@ -137,7 +137,7 @@
                     class="stat-icon-img"
                   />
                 </span>
-                <span class="stat-value">0</span>
+                <span class="stat-value">{{ profileStats.totalTorneios }}</span>
                 <span class="stat-label">Torneios</span>
               </div>
               <div class="stat-item">
@@ -148,7 +148,7 @@
                     class="stat-icon-img"
                   />
                 </span>
-                <span class="stat-value">0</span>
+                <span class="stat-value">{{ profileStats.totalVitorias }}</span>
                 <span class="stat-label">Vitórias</span>
               </div>
               <div class="stat-item">
@@ -159,7 +159,7 @@
                     class="stat-icon-img"
                   />
                 </span>
-                <span class="stat-value">0</span>
+                <span class="stat-value">{{ profileStats.taxaVitorias }}%</span>
                 <span class="stat-label">Taxa</span>
               </div>
             </div>

--- a/frontend/src/app/features/home/home.component.ts
+++ b/frontend/src/app/features/home/home.component.ts
@@ -6,6 +6,9 @@ import { AuthService, User } from '../../core/services/auth.service';
 import { AppRoutes, REDIRECT_DELAY_MS, TRAINER_AVATAR_KEY } from '../../core/constants';
 import { AdminPanelComponent } from './admin-panel/admin-panel.component';
 import { TournamentListComponent } from './tournament-list/tournament-list.component';
+import { EstatisticasService } from '../../core/services/estatisticas.service';
+import { TreinadorDesempenho } from '../../core/models/estatisticas';
+import { forkJoin } from 'rxjs';
 
 type Tab = 'tournaments' | 'profile' | 'admin';
 
@@ -22,6 +25,11 @@ export class HomeComponent implements OnInit {
   isAdmin = false;
   selectedTrainer = 'unknown.png';
   showChangePassword = false;
+  profileStats = {
+    totalTorneios: 0,
+    totalVitorias: 0,
+    taxaVitorias: 0,
+  };
 
   // Alterar Senha
   passwordForm = {
@@ -36,6 +44,7 @@ export class HomeComponent implements OnInit {
   constructor(
     private authService: AuthService,
     private router: Router,
+    private estatisticasService: EstatisticasService,
   ) {}
 
   ngOnInit(): void {
@@ -49,6 +58,7 @@ export class HomeComponent implements OnInit {
 
     this.isAdmin = this.currentUser.admin;
     this.loadSelectedTrainer();
+    this.loadProfileStats();
   }
 
   // ─── Alterar Senha ───────────────────────────────────────────────────────────
@@ -171,5 +181,51 @@ export class HomeComponent implements OnInit {
     if (savedTrainer) {
       this.selectedTrainer = savedTrainer;
     }
+  }
+
+  private loadProfileStats(): void {
+    if (!this.currentUser) return;
+    const treinadorId = this.currentUser.id;
+
+    forkJoin({
+      desempenho: this.estatisticasService.obterDesempenhoGeralTreinador(treinadorId),
+      titulos: this.estatisticasService.obterTitulosTreinador(treinadorId),
+    }).subscribe({
+      next: ({ desempenho, titulos }) => {
+        this.profileStats = this.aggregateProfileStats(
+          desempenho,
+          titulos.totalTitulos || 0,
+        );
+      },
+      error: (error) => {
+        console.error('Erro ao carregar estatísticas do perfil:', error);
+        this.profileStats = {
+          totalTorneios: 0,
+          totalVitorias: 0,
+          taxaVitorias: 0,
+        };
+      },
+    });
+  }
+
+  private aggregateProfileStats(
+    dados: TreinadorDesempenho[],
+    totalTitulos: number,
+  ): {
+    totalTorneios: number;
+    totalVitorias: number;
+    taxaVitorias: number;
+  } {
+    const totalTorneios = new Set(dados.map((item) => item.torneioId)).size;
+    const taxaVitorias =
+      totalTorneios > 0
+        ? Math.round((totalTitulos / totalTorneios) * 100 * 100) / 100
+        : 0;
+
+    return {
+      totalTorneios,
+      totalVitorias: totalTitulos,
+      taxaVitorias,
+    };
   }
 }


### PR DESCRIPTION
## Resumo
- Corrige os cards de estatísticas do perfil, removendo valores fixos.
- Define que `Vitórias` representa títulos de torneio (não vitórias em batalhas).
- Ajusta `Taxa` para ser calculada como `títulos / torneios disputados`.

## Alterações
- Backend: adiciona `GET /api/estatisticas/treinador/{treinadorId}/titulos`.
- Frontend service: adiciona `obterTitulosTreinador(treinadorId)`.
- Home/Profile: carrega desempenho + títulos com `forkJoin` e atualiza os três cards (`Torneios`, `Vitórias`, `Taxa`).

## Validação
- Build do frontend executado com sucesso (`npm run build`).
