### PR TITLE
Fix 500 ao criar torneio quando status não é enviado

### DIFF
--- a/backend/src/main/java/com/ufape/projetobanquinhobd/services/TorneioService.java
+++ b/backend/src/main/java/com/ufape/projetobanquinhobd/services/TorneioService.java
@@ -30,6 +30,9 @@ public class TorneioService {
     private TreinadorRepository treinadorRepository;
 
     public Torneio salvar(Torneio torneio) {
+        if (torneio.getStatus() == null) {
+            torneio.setStatus(StatusTorneio.ABERTO);
+        }
         return torneioRepository.save(torneio);
     }
 

--- a/frontend/src/app/features/home/admin-panel/admin-panel.component.ts
+++ b/frontend/src/app/features/home/admin-panel/admin-panel.component.ts
@@ -340,6 +340,7 @@ export class AdminPanelComponent implements OnInit {
       dataEncerramentoInscricoes: this.newTournament.registrationEndDate,
       dataInicio: this.newTournament.startDate,
       dataFim: this.newTournament.endDate,
+      status: 'ABERTO',
     };
 
     this.torneioService.criarTorneio(torneioParaSalvar).subscribe({


### PR DESCRIPTION
## Resumo\n- corrige erro 500 no POST /api/torneios quando o payload não inclui status\n- backend agora define status = ABERTO por padrão ao salvar torneio sem status\n- frontend passou a enviar status: 'ABERTO' explicitamente na criação\n\n## Resultado\n- criação de torneio volta a funcionar no fluxo admin\n\n## Checklist\n- [x] fallback de status no backend\n- [x] ajuste de payload no frontend\n- [x] validado manualmente